### PR TITLE
Use the language enum when putting items into dynamo.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lint": "tslint --project tsconfig.json",
     "dev": "ts-node-dev --respawn --transpileOnly ./src/app.ts",
     "spec": "speculate --release ${BUILD_NUMBER}",
-    "test": "yarn jest"
+    "test": "yarn jest",
+    "valid": "yarn lint && yarn build && yarn test"
   },
   "dependencies": {
     "aws-sdk": "^2.513.0",

--- a/src/DynamoDB/dynamoDBApi.ts
+++ b/src/DynamoDB/dynamoDBApi.ts
@@ -1,5 +1,5 @@
 import { DocumentClient } from 'aws-sdk/clients/dynamodb';
-import { SentencePair, SentenceSet } from '../models/models';
+import { SentencePair, SentenceSet, Language } from '../models/models';
 import * as uuidv1 from 'uuid/v1';
 
 const client = new DocumentClient({ region: 'eu-west-1' });
@@ -65,8 +65,8 @@ const getSentenceSet = (setId: string): Promise<SentenceSet> => {
 const putSentenceSet = (
   sentencePairs: SentencePair[],
   setName: string,
-  sourceLanguage: string,
-  targetLanguage: string,
+  sourceLanguage: Language,
+  targetLanguage: Language,
   setId?: string
 ): Promise<string> => {
   return Promise.all(

--- a/src/__tests__/processDatasets.ts
+++ b/src/__tests__/processDatasets.ts
@@ -1,5 +1,5 @@
 import { cleanData } from '../processDatasets';
-import { Dataset } from '../models/models';
+import { Dataset, Language } from '../models/models';
 import { DatasetBody } from '../models/requests';
 import { Some, None } from '../models/generics';
 
@@ -10,30 +10,38 @@ describe('cleanData', () => {
       machineTranslatedText: 'Sentence 1.\nSentence 2.',
       humanTranslatedText: 'Sentence 1.\nSentence 2.',
       setName: '',
+      language: 'BULGARIAN',
     };
-    const expectedDataset: Dataset = {
-      englishSentences: ['Sentence 1.', 'Sentence 2.'],
-      humanTranslatedSentences: ['Sentence 1.', 'Sentence 2.'],
-      machineTranslatedSentences: ['Sentence 1.', 'Sentence 2.'],
-      setName: '',
-    };
+    const expectedDataset: Dataset = new Dataset(
+      ['Sentence 1.', 'Sentence 2.'],
+      ['Sentence 1.', 'Sentence 2.'],
+      ['Sentence 1.', 'Sentence 2.'],
+      '',
+      Language.ENGLISH,
+      Language.BULGARIAN
+    );
     const expectedOutput = new Some(expectedDataset);
     expect(cleanData(input)).toEqual(expectedOutput);
   });
 
   test('should return a Some of type Dataset when carriage returns are used to split data', () => {
-    const input = {
+    const input: DatasetBody = {
       setName: 'test',
       englishText: 'Sentence 1.\r\nSentence 2.\r\n',
       humanTranslatedText: 'Sentence 1.\r\nSentence 2.\r\n',
       machineTranslatedText: 'Sentence 1.\r\nSentence 2.\r\n',
+      language: 'BULGARIAN',
     };
-    const expectedOutput = {
-      setName: 'test',
-      englishSentences: ['Sentence 1.', 'Sentence 2.'],
-      humanTranslatedSentences: ['Sentence 1.', 'Sentence 2.'],
-      machineTranslatedSentences: ['Sentence 1.', 'Sentence 2.'],
-    };
+    const expectedOutput = new Some(
+      new Dataset(
+        ['Sentence 1.', 'Sentence 2.'],
+        ['Sentence 1.', 'Sentence 2.'],
+        ['Sentence 1.', 'Sentence 2.'],
+        'test',
+        Language.ENGLISH,
+        Language.BULGARIAN
+      )
+    );
     expect(cleanData(input)).toEqual(expectedOutput);
   });
 
@@ -43,6 +51,7 @@ describe('cleanData', () => {
       machineTranslatedText: '',
       humanTranslatedText: 'Sentence 1.\nSentence 2.',
       setName: '',
+      language: 'BULGARIAN',
     };
     const expectedOutput = new None();
     expect(cleanData(input)).toEqual(expectedOutput);
@@ -54,6 +63,7 @@ describe('cleanData', () => {
       machineTranslatedText: 'Sentence 1.\nSentence 2.\nSentence 3.',
       humanTranslatedText: 'Sentence 1.\nSentence 2.',
       setName: '',
+      language: 'BULGARIAN',
     };
     const expectedOutput = new None();
     expect(cleanData(input)).toEqual(expectedOutput);
@@ -65,6 +75,7 @@ describe('cleanData', () => {
       machineTranslatedText: 'Sentence 1.\nSentence 2.',
       humanTranslatedText: '',
       setName: '',
+      language: 'BULGARIAN',
     };
     const expectedOutput = new None();
     expect(cleanData(input)).toEqual(expectedOutput);
@@ -76,6 +87,7 @@ describe('cleanData', () => {
       machineTranslatedText: 'Sentence 1.\nSentence 2.',
       humanTranslatedText: 'Sentence 1.\nSentence 2.\nSentence 3.',
       setName: '',
+      language: 'BULGARIAN',
     };
     const expectedOutput = new None();
     expect(cleanData(input)).toEqual(expectedOutput);

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -6,8 +6,8 @@ class Dataset {
     public humanTranslatedSentences: string[],
     public machineTranslatedSentences: string[],
     public setName: string,
-    public sourceLanguage: string,
-    public targetLanguage: string
+    public sourceLanguage: Language,
+    public targetLanguage: Language
   ) {}
 }
 
@@ -16,8 +16,8 @@ class SentenceSet {
 
   constructor(
     public name: string,
-    public sourceLanguage: string,
-    public targetLanguage: string,
+    public sourceLanguage: Language,
+    public targetLanguage: Language,
     public sentenceIds?: string[],
     setId?: string
   ) {
@@ -32,8 +32,8 @@ class SentencePair {
     public original: string,
     public humanTranslation: string,
     public machineTranslation: string,
-    public sourceLanguage: string,
-    public targetLanguage: string,
+    public sourceLanguage: Language,
+    public targetLanguage: Language,
     sentenceId?: string
   ) {
     this.sentenceId = sentenceId === undefined ? uuidv1() : sentenceId;
@@ -44,6 +44,7 @@ enum Language {
   BULGARIAN = 'bg',
   GUJARATI = 'gu',
   SWAHILI = 'sw',
+  ENGLISH = 'en',
 }
 
 export { SentenceSet, SentencePair, Dataset, Language };

--- a/src/processDatasets.ts
+++ b/src/processDatasets.ts
@@ -6,15 +6,21 @@ import { Some, None, Option } from './models/generics';
  * Turns body of request into a Dataset. Rejects body if sentence sets are not all of equal length.
  */
 const cleanData = (dataset: DatasetBody): Option<Dataset> => {
-  const regex = /\n?\r/;
-  const englishSentences = dataset.englishText.split(regex);
-  const humanTranslatedSentences = dataset.humanTranslatedText.split(regex);
-  const machineTranslatedSentences = dataset.machineTranslatedText.split(regex);
-  const language: Language = (<any>Language)[dataset.language];
+  const regex = /[\n\r]+/;
+  const englishSentences = dataset.englishText
+    .split(regex)
+    .filter(s => s !== '');
+  const humanTranslatedSentences = dataset.humanTranslatedText
+    .split(regex)
+    .filter(s => s !== '');
+  const machineTranslatedSentences = dataset.machineTranslatedText
+    .split(regex)
+    .filter(s => s !== '');
+  const targetLanguage: Language = (Language as any)[dataset.language];
   if (
     englishSentences.length === machineTranslatedSentences.length &&
     englishSentences.length === humanTranslatedSentences.length &&
-    language !== undefined
+    targetLanguage !== undefined
   ) {
     return new Some(
       new Dataset(
@@ -22,8 +28,8 @@ const cleanData = (dataset: DatasetBody): Option<Dataset> => {
         humanTranslatedSentences,
         machineTranslatedSentences,
         dataset.setName,
-        'english',
-        dataset.language
+        Language.ENGLISH,
+        targetLanguage
       )
     );
   } else {


### PR DESCRIPTION
What's changed:
- The language enum is now used in the dynamoDB API
- Fixed tests and fixed bug highlighted by tests