### PR TITLE
Collect evaluator ID

### DIFF
--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -19,7 +19,8 @@ class SentenceSet {
     public sourceLanguage: Language,
     public targetLanguage: Language,
     public sentenceIds?: string[],
-    setId?: string
+    setId?: string,
+    public evaluatorIds?: string[]
   ) {
     this.setId = setId === undefined ? uuidv1() : setId;
   }

--- a/src/models/requests.ts
+++ b/src/models/requests.ts
@@ -33,10 +33,20 @@ interface DatasetBody {
   machineTranslatedText: string;
 }
 
+interface StartRequest extends Request {
+  body: StartBody;
+}
+
+interface StartBody {
+  setId: string;
+  evaluatorId: string;
+}
+
 export {
   SentencePairEvaluationRequest,
   SentencePairEvaluationRequestBody,
   FeedbackRequest,
   DatasetRequest,
   DatasetBody,
+  StartRequest,
 };

--- a/src/processDatasets.ts
+++ b/src/processDatasets.ts
@@ -1,5 +1,5 @@
 import { Dataset, SentencePair, Language } from './models/models';
-import { putSentenceSet } from './DynamoDB/dynamoDBApi';
+import { putSentenceSetAndPairs } from './DynamoDB/dynamoDBApi';
 import { DatasetBody } from './models/requests';
 import { Some, None, Option } from './models/generics';
 /**
@@ -66,7 +66,7 @@ const submitDataset = (dataset: DatasetBody): Promise<string> => {
   if (cleanedData instanceof Some && cleanedData.value instanceof Dataset) {
     const setName = cleanedData.value.setName;
     const sentencePairs = generateSentencePairs(cleanedData.value);
-    return putSentenceSet(
+    return putSentenceSetAndPairs(
       sentencePairs,
       setName,
       cleanedData.value.sourceLanguage,

--- a/src/uiText.ts
+++ b/src/uiText.ts
@@ -4,8 +4,10 @@ const getErrorText = (errorCode: string): string => {
       return 'Unable to save evaluation score.';
     case 'getEvaluation':
       return 'Unable to retrieve sentence pair.';
-    case 'postStart':
+    case 'postStartFailSentenceSet':
       return 'Could not get set of sentences for evaluation.';
+    case 'postStartFailEvaluatorId':
+      return 'Could not save your evaluation ID.';
     case 'postFeedback':
       return 'Could not save feedback.';
     case 'postDataset':

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -35,6 +35,15 @@
                           method="POST">
                         <div class="row justify-content-center form-group">
                             <div class="col-md-6">
+                                <label for="evaluatorId">Enter your evaluator ID:</label>
+                                <input class="form-control"
+                                       name="evaluatorId"
+                                       required>
+                                </select>
+                            </div>
+                        </div>
+                        <div class="row justify-content-center form-group">
+                            <div class="col-md-6">
                                 <label for="setId">Pick the set you have been asked to
                                     evaluate:</label>
                                 <select class="form-control"


### PR DESCRIPTION
What's changed:
- User now inputs an evaluator Id when starting the evaluation so that we know who has evaluated the sets
- Added explicit conversion from DynamoDB object to SentenceSet object