### PR TITLE
Update tslint rules

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -10,5 +10,8 @@
     "no-console": [true, "log"],
     "no-empty-interface": false
   },
-  "rulesDirectory": []
+  "rulesDirectory": [],
+  "linterOptions": {
+    "exclude": ["src/DynamoDB/dynamoDBApi.ts"]
+  }
 }


### PR DESCRIPTION
Exclude DynamoDB file from linter to allow conversion from `AttributeSet` to `SentenceSet` using string literals.

This is not an ideal solution to the problem as it requires a manual conversion between types and turning off the linter in part. But the [aws-sdk](https://www.npmjs.com/package/aws-sdk) does not provide generic functions to interact with the database and always returns an `AttributeSet`