### PR TITLE
Split out start screen and select sentence set into 2 views

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -36,12 +36,16 @@ app.use(express.static('public'));
 app.set('view engine', 'hbs');
 
 app.get('/', (req: Request, res: Response) => {
+  res.render('index');
+});
+
+app.get('/start', (req: Request, res: Response) => {
   getSentenceSets().then(sentenceSets => {
-    res.render('index', { sentenceSets, datasetSubmissionUrl: '/dataset' });
+    res.render('start', { sentenceSets, datasetSubmissionUrl: '/dataset' });
   });
 });
 
-app.post('/start', (req: StartRequest, res: Response) => {
+app.post('/beginEvaluation', (req: StartRequest, res: Response) => {
   const setId = req.body.setId;
   const evaluatorId = req.body.evaluatorId;
   getSentenceSet(setId)

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -25,41 +25,17 @@
                     <h1 class="text-center text-primary">Sentence Pair Evaluation</h1>
                     <h3 class="text-center text-secondary margin-top-5percent">The purpose of the evaluation is to
                         assess how well machine translation performs. You will be presented with a series of pairs of
-                        sentences.
-                        Sentence 1 has been translated by a human and sentence 2 has been translated by a machine.
-                        Please use the slider to indicate how closely the meaning of the first sentence matches the
-                        meaning of the second.
+                        sentences. Please use the slider to indicate how closely the meaning of the first sentence
+                        matches the meaning of the second. If you are happy to take part in the evaluation click 'OK' to
+                        begin.
                     </h3>
                     <form class="margin-top-5percent"
                           action="/start"
-                          method="POST">
-                        <div class="row justify-content-center form-group">
-                            <div class="col-md-6">
-                                <label for="evaluatorId">Enter your evaluator ID:</label>
-                                <input class="form-control"
-                                       name="evaluatorId"
-                                       required>
-                                </select>
-                            </div>
-                        </div>
-                        <div class="row justify-content-center form-group">
-                            <div class="col-md-6">
-                                <label for="setId">Pick the set you have been asked to
-                                    evaluate:</label>
-                                <select class="form-control"
-                                        name="setId"
-                                        required>
-                                    <option></option>
-                                    {{#each sentenceSets}}
-                                    <option value="{{this.setId}}">{{this.name}}</option>
-                                    {{/each}}
-                                </select>
-                            </div>
-                        </div>
+                          method="GET">
                         <div class="row justify-content-center form-group">
                             <div class="col-md-2">
                                 <button type="submit"
-                                        class="btn btn-primary btn-block">Begin</button>
+                                        class="btn btn-primary btn-block">Ok</button>
                             </div>
                         </div>
                     </form>

--- a/views/start.hbs
+++ b/views/start.hbs
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+
+    <head>
+        <!-- Adding bootstrap CSS styles -->
+        <link rel="stylesheet"
+              href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
+              integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T"
+              crossorigin="anonymous">
+
+        <meta charset="utf-8">
+        <meta name="viewport"
+              content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+        <title>Sentence Pairs</title>
+        <link rel="stylesheet"
+              type="text/css"
+              href="main.css" />
+    </head>
+
+    <body>
+        <div class="container">
+            <div class="row align-items-center">
+                <div class="col margin-top-5percent">
+                    <h1 class="text-center text-primary">Sentence Pair Evaluation</h1>
+                    <h3 class="text-center text-secondary margin-top-5percent">
+                        Please enter your evaluator ID and select the sentence set you have been asked to evaluate
+                    </h3>
+                    <form class="margin-top-5percent"
+                          action="/beginEvaluation"
+                          method="POST">
+                        <div class="row justify-content-center form-group">
+                            <div class="col-md-6">
+                                <label for="evaluatorId">Enter your evaluator ID:</label>
+                                <input class="form-control"
+                                       name="evaluatorId"
+                                       required>
+                                </select>
+                            </div>
+                        </div>
+                        <div class="row justify-content-center form-group">
+                            <div class="col-md-6">
+                                <label for="setId">Pick the set you have been asked to
+                                    evaluate:</label>
+                                <select class="form-control"
+                                        name="setId"
+                                        required>
+                                    <option></option>
+                                    {{#each sentenceSets}}
+                                    <option value="{{this.setId}}">{{this.name}}</option>
+                                    {{/each}}
+                                </select>
+                            </div>
+                        </div>
+                        <div class="row justify-content-center form-group">
+                            <div class="col-md-2">
+                                <button type="submit"
+                                        class="btn btn-primary btn-block">Start Evaluation</button>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </body>
+
+</html>


### PR DESCRIPTION
What's changed:
- Previously the introduction to the test text and the functionality to select your sentence set were all on the same screen. Now the tool has an intro screen:
![Screenshot_2019-09-11 Sentence Pairs](https://user-images.githubusercontent.com/6666113/64718733-b5c56c80-d4be-11e9-8dba-a5bed5192e4c.png)
And a select sentence set screen:
![Screenshot_2019-09-11 Sentence Pairs(1)](https://user-images.githubusercontent.com/6666113/64718770-c544b580-d4be-11e9-9d26-111887a47b84.png)

TODO: Add official text