### PR TITLE
Change evaluatorIds and sentenceIds to be modelled as sets not arrays

### DIFF
--- a/src/DynamoDB/dynamoDBApi.ts
+++ b/src/DynamoDB/dynamoDBApi.ts
@@ -30,7 +30,7 @@ const getSentenceSets = (): Promise<SentenceSet[]> => {
     .then(output => {
       const items = output.Items || [];
       return items.map(sentenceSet => {
-        return (sentenceSet as unknown) as SentenceSet;
+        return convertAttributeMapToSentenceSet(sentenceSet);
       });
     });
 };
@@ -80,7 +80,7 @@ const putSentenceSetAndPairs = (
       setName,
       sourceLanguage,
       targetLanguage,
-      sentencePairsIds,
+      new Set(sentencePairsIds),
       setId
     );
     return putSentenceSet(sentenceSet);
@@ -218,9 +218,9 @@ const convertAttributeMapToSentenceSet = (
     item['name'],
     item['sourceLanguage'],
     item['targetLanguage'],
-    sentenceIds,
+    new Set(sentenceIds),
     item['setId'],
-    evaluatorIds
+    new Set(evaluatorIds)
   );
 };
 
@@ -228,9 +228,9 @@ const convertAttributeMapToSentenceSet = (
  * Some fairly horrible logic to ensure that an empty or undefined set is not put into dynamo
  */
 const constructSentenceSetItem = (sentenceSet: SentenceSet) => {
-  const sentenceIds: string[] = sentenceSet.sentenceIds || [];
-  const evaluatorIds: string[] = sentenceSet.evaluatorIds || [];
-  if (sentenceIds.length < 1 && evaluatorIds.length < 1) {
+  const sentenceIds: Set<string> = sentenceSet.sentenceIds || new Set();
+  const evaluatorIds: Set<string> = sentenceSet.evaluatorIds || new Set();
+  if (sentenceIds.size < 1 && evaluatorIds.size < 1) {
     return {
       setId: sentenceSet.setId,
       name: sentenceSet.name,
@@ -238,7 +238,7 @@ const constructSentenceSetItem = (sentenceSet: SentenceSet) => {
       targetLanguage: sentenceSet.targetLanguage.toUpperCase(),
     };
   }
-  if (sentenceIds.length < 1) {
+  if (sentenceIds.size < 1) {
     return {
       setId: sentenceSet.setId,
       name: sentenceSet.name,
@@ -247,7 +247,7 @@ const constructSentenceSetItem = (sentenceSet: SentenceSet) => {
       evaluatorIds: client.createSet(Array.from(evaluatorIds)),
     };
   }
-  if (evaluatorIds.length < 1) {
+  if (evaluatorIds.size < 1) {
     return {
       setId: sentenceSet.setId,
       sentenceIds: client.createSet(Array.from(sentenceIds)),

--- a/src/app.ts
+++ b/src/app.ts
@@ -51,10 +51,14 @@ app.post('/beginEvaluation', (req: StartRequest, res: Response) => {
   getSentenceSet(setId)
     .then(sentenceSet => {
       addEvaluatorIdToSentenceSet(evaluatorId, sentenceSet)
-        .then(x => {
+        .then(result => {
+          const sentenceIdsList = Array.from(
+            sentenceSet.sentenceIds || new Set()
+          );
           res.redirect(
-            `/evaluation?idList=${JSON.stringify(sentenceSet.sentenceIds) ||
-              []}&setId=${setId}&numOfPracticeSentences=5&evaluatorId=${evaluatorId}`
+            `/evaluation?idList=${JSON.stringify(
+              sentenceIdsList
+            )}&setId=${setId}&numOfPracticeSentences=5&evaluatorId=${evaluatorId}`
           );
         })
         .catch(error => {
@@ -76,10 +80,10 @@ const addEvaluatorIdToSentenceSet = (
   evaluatorId: string,
   sentenceSet: SentenceSet
 ): Promise<string> => {
-  const evaluatorIds: string[] =
+  const evaluatorIds: Set<string> =
     sentenceSet.evaluatorIds === undefined
-      ? (sentenceSet.evaluatorIds = [evaluatorId])
-      : sentenceSet.evaluatorIds.concat(evaluatorId);
+      ? (sentenceSet.evaluatorIds = new Set([evaluatorId]))
+      : sentenceSet.evaluatorIds.add(evaluatorId);
 
   const updatedSentenceSet = new SentenceSet(
     sentenceSet.name,
@@ -109,7 +113,7 @@ app.post('/evaluation', (req: SentencePairEvaluationRequest, res: Response) => {
     );
   } else {
     putSentencePairScore(id, score, evaluatorId)
-      .then(x =>
+      .then(result =>
         res.redirect(
           `/evaluation?idList=${body.idList}&setId=${setId}&evaluatorId=${evaluatorId}`
         )
@@ -183,7 +187,7 @@ app.get('/end', (req: Request, res: Response) => {
 app.post('/dataset', (req: DatasetRequest, res: Response) => {
   const dataset: DatasetBody = req.body;
   submitDataset(dataset)
-    .then(x => {
+    .then(result => {
       res.redirect('/success');
     })
     .catch(error => {

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -18,9 +18,9 @@ class SentenceSet {
     public name: string,
     public sourceLanguage: Language,
     public targetLanguage: Language,
-    public sentenceIds?: string[],
+    public sentenceIds?: Set<string>,
     setId?: string,
-    public evaluatorIds?: string[]
+    public evaluatorIds?: Set<string>
   ) {
     this.setId = setId === undefined ? uuidv1() : setId;
   }


### PR DESCRIPTION
What's changed:
Evaluator Ids and sentence Ids are now modelled as sets rather than arrays in the SentenceSet model. This means there will be no duplication in the list when saving sentence Ids or evaluator Ids to dynamoDB as dynamo treats all lists as sets. It has been decided that is preferable behaviour to requiring a user to only be able to use their ID once per set they evaluate. This is mainly to allow easy filtering out of demos of the tool to evaluators as the same ID can be used every time.