### PR TITLE
Pass current sentence index as a parameter

### DIFF
--- a/src/models/requests.ts
+++ b/src/models/requests.ts
@@ -3,11 +3,11 @@ import { Request } from 'express';
 interface SentencePairEvaluationRequestBody {
   id: string;
   setId: string;
-  idList: string[];
   score: number;
   evaluatorId: string;
   numOfPracticeSentences: number;
   setSize: number;
+  sentenceNum: number;
 }
 
 interface SentencePairEvaluationRequest extends Request {

--- a/views/evaluation.hbs
+++ b/views/evaluation.hbs
@@ -75,9 +75,6 @@
                                                    name="score">
                                         </div>
                                         <input type="hidden"
-                                               name="idList"
-                                               value={{idList}} />
-                                        <input type="hidden"
                                                name="id"
                                                value={{sentencePairId}} />
                                         <input type="hidden"
@@ -92,6 +89,9 @@
                                         <input type="hidden"
                                                name="setSize"
                                                value={{setSize}} />
+                                        <input type="hidden"
+                                               name="sentenceNum"
+                                               value={{sentenceNum}} />
                                     </div>
                                     <div class="row justify-content-center form-group">
                                         <div class="col-sm-2">
@@ -105,7 +105,7 @@
                     </div>
                     <div class="row">
                         <div class="col">
-                            <p class="float-right">{{remainingSentences}}/{{setSize}}</p>
+                            <p class="float-right">{{sentenceNum}}/{{setSize}}</p>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
What's changed:
- Rather than passing the entire list of sentence IDs as a parameter an index is passed instead. This is good as it means it is now possible to handle larger test sets without ridiculously large parameter lists. It also means that it is still possible to bookmark the page and come back to the test later and have your progress saved. However it means that it is now necessary to make 2 database calls one to get the list of sentence Ids and one to get the sentence pair for that Id
