### PR TITLE
Submit sentences for evaluation as a json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "dotenv": "^8.1.0",
     "express": "^4.17.1",
     "hbs": "^4.0.4",
+    "multer": "^1.4.2",
     "typescript": "^3.5.3",
     "uuid": "^3.3.3"
   },
@@ -26,6 +27,7 @@
     "@types/dotenv": "^6.1.1",
     "@types/express": "^4.17.0",
     "@types/jest": "^24.0.18",
+    "@types/multer": "^1.3.9",
     "@types/node": "^12.7.2",
     "@types/uuid": "^3.4.5",
     "jest": "^24.9.0",

--- a/src/__tests__/processDatasets.ts
+++ b/src/__tests__/processDatasets.ts
@@ -1,17 +1,19 @@
 import { cleanData } from '../processDatasets';
 import { Dataset, Language } from '../models/models';
-import { DatasetBody } from '../models/requests';
+import { DatasetBody, DatasetFile } from '../models/requests';
 import { Some, None } from '../models/generics';
 
 describe('cleanData', () => {
   test('should return a Some of type Dataset if dataset body is valid', () => {
     const input: DatasetBody = {
-      sourceText: 'Sentence 1.\nSentence 2.',
-      machineTranslatedText: 'Sentence 1.\nSentence 2.',
-      humanTranslatedText: 'Sentence 1.\nSentence 2.',
       setName: '',
       sourceLanguage: 'ENGLISH',
       targetLanguage: 'BULGARIAN',
+    };
+    const file: DatasetFile = {
+      sourceText: 'Sentence 1.\nSentence 2.',
+      machineTranslatedText: 'Sentence 1.\nSentence 2.',
+      humanTranslatedText: 'Sentence 1.\nSentence 2.',
     };
     const expectedDataset: Dataset = new Dataset(
       ['Sentence 1.', 'Sentence 2.'],
@@ -22,17 +24,19 @@ describe('cleanData', () => {
       Language.BULGARIAN
     );
     const expectedOutput = new Some(expectedDataset);
-    expect(cleanData(input)).toEqual(expectedOutput);
+    expect(cleanData(input, file)).toEqual(expectedOutput);
   });
 
   test('should return a Some of type Dataset when carriage returns are used to split data', () => {
     const input: DatasetBody = {
       setName: 'test',
+      sourceLanguage: 'ENGLISH',
+      targetLanguage: 'BULGARIAN',
+    };
+    const file: DatasetFile = {
       sourceText: 'Sentence 1.\r\nSentence 2.\r\n',
       humanTranslatedText: 'Sentence 1.\r\nSentence 2.\r\n',
       machineTranslatedText: 'Sentence 1.\r\nSentence 2.\r\n',
-      sourceLanguage: 'ENGLISH',
-      targetLanguage: 'BULGARIAN',
     };
     const expectedOutput = new Some(
       new Dataset(
@@ -44,58 +48,66 @@ describe('cleanData', () => {
         Language.BULGARIAN
       )
     );
-    expect(cleanData(input)).toEqual(expectedOutput);
+    expect(cleanData(input, file)).toEqual(expectedOutput);
   });
 
   test('should return a None if machine translated text does not have enough sentences', () => {
     const input: DatasetBody = {
-      sourceText: 'Sentence 1.\nSentence 2.',
-      machineTranslatedText: '',
-      humanTranslatedText: 'Sentence 1.\nSentence 2.',
       setName: '',
       sourceLanguage: 'ENGLISH',
       targetLanguage: 'BULGARIAN',
     };
+    const file: DatasetFile = {
+      sourceText: 'Sentence 1.\nSentence 2.',
+      machineTranslatedText: '',
+      humanTranslatedText: 'Sentence 1.\nSentence 2.',
+    };
     const expectedOutput = new None();
-    expect(cleanData(input)).toEqual(expectedOutput);
+    expect(cleanData(input, file)).toEqual(expectedOutput);
   });
 
   test('should return a None if machine translated text has too many sentences', () => {
     const input: DatasetBody = {
-      sourceText: 'Sentence 1.\nSentence 2.',
-      machineTranslatedText: 'Sentence 1.\nSentence 2.\nSentence 3.',
-      humanTranslatedText: 'Sentence 1.\nSentence 2.',
       setName: '',
       sourceLanguage: 'ENGLISH',
       targetLanguage: 'BULGARIAN',
     };
+    const file: DatasetFile = {
+      sourceText: 'Sentence 1.\nSentence 2.',
+      machineTranslatedText: 'Sentence 1.\nSentence 2.\nSentence 3.',
+      humanTranslatedText: 'Sentence 1.\nSentence 2.',
+    };
     const expectedOutput = new None();
-    expect(cleanData(input)).toEqual(expectedOutput);
+    expect(cleanData(input, file)).toEqual(expectedOutput);
   });
 
   test('should return a None if human translated text does not have enough sentences', () => {
     const input: DatasetBody = {
-      sourceText: 'Sentence 1.\nSentence 2.',
-      machineTranslatedText: 'Sentence 1.\nSentence 2.',
-      humanTranslatedText: '',
       setName: '',
       sourceLanguage: 'ENGLISH',
       targetLanguage: 'BULGARIAN',
     };
+    const file: DatasetFile = {
+      sourceText: 'Sentence 1.\nSentence 2.',
+      machineTranslatedText: 'Sentence 1.\nSentence 2.',
+      humanTranslatedText: '',
+    };
     const expectedOutput = new None();
-    expect(cleanData(input)).toEqual(expectedOutput);
+    expect(cleanData(input, file)).toEqual(expectedOutput);
   });
 
   test('should return a None if human translated text has too many sentences', () => {
     const input: DatasetBody = {
-      sourceText: 'Sentence 1.\nSentence 2.',
-      machineTranslatedText: 'Sentence 1.\nSentence 2.',
-      humanTranslatedText: 'Sentence 1.\nSentence 2.\nSentence 3.',
       setName: '',
       sourceLanguage: 'ENGLISH',
       targetLanguage: 'BULGARIAN',
     };
+    const file: DatasetFile = {
+      sourceText: 'Sentence 1.\nSentence 2.',
+      machineTranslatedText: 'Sentence 1.\nSentence 2.',
+      humanTranslatedText: 'Sentence 1.\nSentence 2.\nSentence 3.',
+    };
     const expectedOutput = new None();
-    expect(cleanData(input)).toEqual(expectedOutput);
+    expect(cleanData(input, file)).toEqual(expectedOutput);
   });
 });

--- a/src/models/requests.ts
+++ b/src/models/requests.ts
@@ -32,6 +32,9 @@ interface DatasetBody {
   setName: string;
   sourceLanguage: string;
   targetLanguage: string;
+}
+
+interface DatasetFile {
   sourceText: string;
   humanTranslatedText: string;
   machineTranslatedText: string;
@@ -52,5 +55,6 @@ export {
   FeedbackRequest,
   DatasetRequest,
   DatasetBody,
+  DatasetFile,
   StartRequest,
 };

--- a/src/processDatasets.ts
+++ b/src/processDatasets.ts
@@ -1,17 +1,22 @@
 import { Dataset, SentencePair, Language } from './models/models';
 import { putSentenceSetAndPairs } from './DynamoDB/dynamoDBApi';
-import { DatasetBody } from './models/requests';
+import { DatasetBody, DatasetFile } from './models/requests';
 import { Some, None, Option } from './models/generics';
 /**
  * Turns body of request into a Dataset. Rejects body if sentence sets are not all of equal length.
  */
-const cleanData = (dataset: DatasetBody): Option<Dataset> => {
+const cleanData = (
+  dataset: DatasetBody,
+  datasetFile: DatasetFile
+): Option<Dataset> => {
   const regex = /[\n\r]+/;
-  const sourceSentences = dataset.sourceText.split(regex).filter(s => s !== '');
-  const humanTranslatedSentences = dataset.humanTranslatedText
+  const sourceSentences = datasetFile.sourceText
     .split(regex)
     .filter(s => s !== '');
-  const machineTranslatedSentences = dataset.machineTranslatedText
+  const humanTranslatedSentences = datasetFile.humanTranslatedText
+    .split(regex)
+    .filter(s => s !== '');
+  const machineTranslatedSentences = datasetFile.machineTranslatedText
     .split(regex)
     .filter(s => s !== '');
   const sourceLanguage: Language = (Language as any)[dataset.sourceLanguage];
@@ -60,8 +65,11 @@ const generateSentencePairs = (dataset: Dataset): SentencePair[] => {
   return sentencePairs;
 };
 
-const submitDataset = (dataset: DatasetBody): Promise<string> => {
-  const cleanedData = cleanData(dataset);
+const submitDataset = (
+  dataset: DatasetBody,
+  datasetFile: DatasetFile
+): Promise<string> => {
+  const cleanedData = cleanData(dataset, datasetFile);
   if (cleanedData instanceof Some && cleanedData.value instanceof Dataset) {
     const setName = cleanedData.value.setName;
     const sentencePairs = generateSentencePairs(cleanedData.value);

--- a/views/dataset.hbs
+++ b/views/dataset.hbs
@@ -24,19 +24,32 @@
                  src="./media/horizontal_light.png" />
         </div>
         <div class="container">
-            <div class="row align-items-center">
-                <div class="col text-primary-dark-grey">
+            <div class="row justify-content-center">
+                <div class="col-sm-10 text-primary-dark-grey">
                     <h1 class="text-center text-primary-mid-green">Text for Evaluation</h1>
                     <p class="margin-top-5percent">This page is for submission of data sets to be evaluated. The user
-                        MUST provide a machine translation and a human translation as well as a name for
-                        the sentence set. This name will be given to evaluators to identify the data set they should
-                        analyse. Each individual sentence must be on a new line. The assumption is made that each block
+                        MUST a name for the sentence set as well as the source language and target language. This name
+                        will be given to evaluators to identify the data set they should analyse. The file provided MUST
+                        be a json file containing JSON of the following form:
+                    </p>
+                    <code>
+                        {
+                            "sourceText":"Sentence1.\nSentence2.",
+                            "humanTranslatedText": "HTSentence1.\nHTSentence2.",
+                            "machineTranslatedText": "MTSentence1.\nMTSentence2."
+                        }
+                    </code>
+                    <p class="margin-top-5percent">
+
+                        Each individual sentence must be separated by a new line character. The assumption is made that
+                        each block
                         of text will have the same number of sentences and that the sentences in each block match. E.g.
                         Sentence 1 in the Human Translated Text input and sentence 1 in the machine translated text
                         input will both be translations of sentence 1 of the Source Text input.
                     </p>
                     <form action="/dataset"
-                          method="POST">
+                          method="POST"
+                          enctype="multipart/form-data">
                         <div class="form-row">
                             <div class="form-group col-md-4">
 
@@ -70,29 +83,10 @@
                             </div>
                         </div>
                         <div class="form-group">
-                            <label for="sourceText">Source Text</label>
-                            <textarea class="form-control"
-                                      name="sourceText"
-                                      id="sourceText"
-                                      rows="10"
-                                      required></textarea>
-                        </div>
-
-                        <div class="form-group">
-                            <label for="humanTranslatedText">Human Translated Text</label>
-                            <textarea class="form-control"
-                                      name="humanTranslatedText"
-                                      id="humanTranslatedText"
-                                      rows="10"
-                                      required></textarea>
-                        </div>
-                        <div class="form-group">
-                            <label for="machineTranslatedText">Machine Translated Text</label>
-                            <textarea class="form-control"
-                                      name="machineTranslatedText"
-                                      id="machineTranslatedText"
-                                      rows="10"
-                                      required></textarea>
+                            <label for="sentences">Choose file</label>
+                            <input type="file"
+                                   class="form-control-file"
+                                   name="sentences">
                         </div>
                         <div class="form-group">
                             <div class="form-check">

--- a/yarn.lock
+++ b/yarn.lock
@@ -350,7 +350,7 @@
     "@types/node" "*"
     "@types/range-parser" "*"
 
-"@types/express@^4.17.0":
+"@types/express@*", "@types/express@^4.17.0":
   version "4.17.1"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.1.tgz#4cf7849ae3b47125a567dfee18bfca4254b88c5c"
   integrity sha512-VfH/XCP0QbQk5B5puLqTLEeFgR8lfCJHZJKkInZ9mkYd+u8byX0kztXEQxEk4wZXJs8HI+7km2ALXjn4YKcX9w==
@@ -395,6 +395,13 @@
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.1.tgz#dc488842312a7f075149312905b5e3c0b054c79d"
   integrity sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw==
+
+"@types/multer@^1.3.9":
+  version "1.3.9"
+  resolved "https://registry.yarnpkg.com/@types/multer/-/multer-1.3.9.tgz#da72b5d616cba2aa0eede71d9459e4234ec33a60"
+  integrity sha512-aKUwxl4yH87G8b3wgmruBVdOWiG9qqmc4Epjt5Uz3mqaMZwx3dkMm4tHn5nnwBk2NT+X4t5yADJiEv/NfMFQIg==
+  dependencies:
+    "@types/express" "*"
 
 "@types/node@*", "@types/node@^12.7.2":
   version "12.7.2"
@@ -533,6 +540,11 @@ anymatch@^2.0.0:
   dependencies:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
+
+append-field@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/append-field/-/append-field-1.0.0.tgz#1e3440e915f0b1203d23748e78edd7b9b5b43e56"
+  integrity sha1-HjRA6RXwsSA9I3SOeO3XubW0PlY=
 
 aproba@^1.0.3:
   version "1.2.0"
@@ -842,6 +854,14 @@ builtin-modules@^1.1.1:
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
   integrity sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=
 
+busboy@^0.2.11:
+  version "0.2.14"
+  resolved "https://registry.yarnpkg.com/busboy/-/busboy-0.2.14.tgz#6c2a622efcf47c57bbbe1e2a9c37ad36c7925453"
+  integrity sha1-bCpiLvz0fFe7vh4qnDetNseSVFM=
+  dependencies:
+    dicer "0.2.5"
+    readable-stream "1.1.x"
+
 bytes@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.0.tgz#f6cf7933a360e0588fa9fde85651cdc7f805d1f6"
@@ -991,6 +1011,16 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
+
+concat-stream@^1.5.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
+  integrity sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
+  dependencies:
+    buffer-from "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^2.2.2"
+    typedarray "^0.0.6"
 
 console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
@@ -1194,6 +1224,14 @@ detect-newline@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
   integrity sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=
+
+dicer@0.2.5:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/dicer/-/dicer-0.2.5.tgz#5996c086bb33218c812c090bddc09cd12facb70f"
+  integrity sha1-WZbAhrszIYyBLAkL3cCc0S+stw8=
+  dependencies:
+    readable-stream "1.1.x"
+    streamsearch "0.1.2"
 
 diff-sequences@^24.9.0:
   version "24.9.0"
@@ -1866,7 +1904,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@~2.0.3:
+inherits@2, inherits@2.0.4, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -2054,6 +2092,11 @@ is-wsl@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
+
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
 
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -2855,6 +2898,20 @@ ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
+multer@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/multer/-/multer-1.4.2.tgz#2f1f4d12dbaeeba74cb37e623f234bf4d3d2057a"
+  integrity sha512-xY8pX7V+ybyUpbYMxtjM9KAiD9ixtg5/JkeKUTD6xilfDv0vzzOFcCp4Ljb1UU3tSOM3VTZtKo63OmzOrGi3Cg==
+  dependencies:
+    append-field "^1.0.0"
+    busboy "^0.2.11"
+    concat-stream "^1.5.2"
+    mkdirp "^0.5.1"
+    object-assign "^4.1.1"
+    on-finished "^2.3.0"
+    type-is "^1.6.4"
+    xtend "^4.0.0"
+
 nan@^2.12.1:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
@@ -3013,7 +3070,7 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-object-assign@^4.0.1, object-assign@^4.1.0:
+object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -3054,7 +3111,7 @@ object.pick@^1.3.0:
   dependencies:
     isobject "^3.0.1"
 
-on-finished@~2.3.0:
+on-finished@^2.3.0, on-finished@~2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
   integrity sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=
@@ -3432,7 +3489,17 @@ read-pkg@^3.0.0:
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
-readable-stream@^2.0.6, readable-stream@^2.3.0, readable-stream@^2.3.5:
+readable-stream@1.1.x:
+  version "1.1.14"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
+  integrity sha1-fPTFTvZI44EwhMY23SB54WbAgdk=
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "0.0.1"
+    string_decoder "~0.10.x"
+
+readable-stream@^2.0.6, readable-stream@^2.2.2, readable-stream@^2.3.0, readable-stream@^2.3.5:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   integrity sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
@@ -3876,6 +3943,11 @@ stealthy-require@^1.1.1:
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
   integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
 
+streamsearch@0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-0.1.2.tgz#808b9d0e56fc273d809ba57338e929919a1a9f1a"
+  integrity sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=
+
 string-length@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/string-length/-/string-length-2.0.0.tgz#d40dbb686a3ace960c1cffca562bf2c45f8363ed"
@@ -3909,6 +3981,11 @@ string-width@^3.0.0, string-width@^3.1.0:
     emoji-regex "^7.0.1"
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
+
+string_decoder@~0.10.x:
+  version "0.10.31"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
+  integrity sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=
 
 string_decoder@~1.1.1:
   version "1.1.1"
@@ -4229,13 +4306,18 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-type-is@~1.6.17, type-is@~1.6.18:
+type-is@^1.6.4, type-is@~1.6.17, type-is@~1.6.18:
   version "1.6.18"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
   integrity sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==
   dependencies:
     media-typer "0.3.0"
     mime-types "~2.1.24"
+
+typedarray@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
+  integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
 typescript@^3.5.3:
   version "3.5.3"


### PR DESCRIPTION
What's changed
- The sentences to be evaluated are now submitted as a file rather than as text fields in a form. This allows larger datasets to be uploaded and tested without hitting data limits for form size.