### PR TITLE
Switch from free text for evaluator Id to dropdown

### DIFF
--- a/src/routes/start.ts
+++ b/src/routes/start.ts
@@ -4,9 +4,37 @@ import { getSentenceSets } from '../DynamoDB/dynamoDBApi';
 const buildStartRoute = (app: Application) => {
   app.get('/start', (req: Request, res: Response) => {
     getSentenceSets().then(sentenceSets => {
-      res.render('start', { sentenceSets });
+      res.render('start', { sentenceSets, evaluatorIds });
     });
   });
 };
+
+const evaluatorIds = [
+  'tester',
+  'BBC_Bulgarian_01',
+  'BBC_Bulgarian_02',
+  'BBC_Bulgarian_03',
+  'BBC_Bulgarian_04',
+  'BBC_Swahili_01',
+  'BBC_Swahili_02',
+  'BBC_Swahili_03',
+  'BBC_Swahili_04',
+  'BBC_Gujarati_01',
+  'BBC_Gujarati_02',
+  'BBC_Gujarati_03',
+  'BBC_Gujarati_04',
+  'DW_Bulgarian_01',
+  'DW_Bulgarian_02',
+  'DW_Bulgarian_03',
+  'DW_Bulgarian_04',
+  'DW_Swahili_01',
+  'DW_Swahili_02',
+  'DW_Swahili_03',
+  'DW_Swahili_04',
+  'DW_Gujarati_01',
+  'DW_Gujarati_02',
+  'DW_Gujarati_03',
+  'DW_Gujarati_04',
+];
 
 export { buildStartRoute };

--- a/views/start.hbs
+++ b/views/start.hbs
@@ -47,10 +47,14 @@
                           method="POST">
                         <div class="row justify-content-center form-group">
                             <div class="col-md-6">
-                                <label for="evaluatorId">Enter your evaluator ID:</label>
-                                <input class="form-control"
-                                       name="evaluatorId"
-                                       required>
+                                <label for="evaluatorId">Select your evaluator ID:</label>
+                                <select class="form-control"
+                                        name="evaluatorId"
+                                        required>
+                                    <option></option>
+                                    {{#each evaluatorIds}}
+                                    <option value={{this}}>{{this}}</option>
+                                    {{/each}}
                                 </select>
                             </div>
                         </div>


### PR DESCRIPTION
What's changed:
- Instead of a free text box for entering the Evaluator Id evaluator will select their Id from a drop down menu. A free text box was leading to inconsistencies in the Ids even with only a couple of evaluators

Long term there could be some optimisation to keep the evaluator Id list a little shorter. For example selecting language to evaluate first but I don't think this needs to be done now.