### PR TITLE
refactor: Move starting app out to dedicated server file

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
   "description": "Description",
   "author": "susiecoleman",
   "license": "UNLICENSED",
-  "main": "./dist/app.js",
+  "main": "./dist/server.js",
   "scripts": {
     "start": "node .",
     "build": "tsc",
     "lint": "tslint --project tsconfig.json",
-    "dev": "ts-node-dev --respawn --transpileOnly ./src/app.ts",
+    "dev": "ts-node-dev --respawn --transpileOnly ./src/server.ts",
     "spec": "speculate --release ${BUILD_NUMBER}",
     "test": "yarn jest",
     "valid": "yarn lint && yarn build && yarn test"

--- a/src/app.ts
+++ b/src/app.ts
@@ -13,12 +13,9 @@ import { buildEndRoute } from './routes/end';
 import { buildSuccessRoute } from './routes/success';
 import { buildErrorRoute } from './routes/error';
 import { buildStatusRoute } from './routes/status';
-
 import './config';
-import { logger } from './utils/logger';
 
 const app: Application = express();
-const port = process.env.PORT || 8080;
 
 // support parsing of application/json type post data
 app.use(express.json());
@@ -42,6 +39,4 @@ buildSuccessRoute(app);
 buildErrorRoute(app);
 buildStatusRoute(app);
 
-app.listen(port, () => {
-  logger.info(`App running on port ${port}`);
-});
+export default app;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,7 @@
+const port = process.env.PORT || 8080;
+import { logger } from './utils/logger';
+import app from './app';
+
+app.listen(port, () => {
+  logger.info(`App running on port ${port}`);
+});


### PR DESCRIPTION
What's changed:
- There is now a separate file where the `app.listen` command to start the server is run

Why?
- Refactor to make testing of the app easier