### PR TITLE
Refactor: rename scores column

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ The names of the database tables are in the [`.env`](./.env) file. There are 4 t
 
 3. SENTENCE_SCORES_TABLE_NAME - Contains scores given, which sentence pair the score was for and who gave it.
 
-| scoreId | evaluatorId | score  | sentencePairId |
-|---------|-------------|--------|----------------|
-| string  | string      | string | string         |
+| scoreId | evaluatorId | q1Score  | sentencePairId |
+|---------|-------------|----------|----------------|
+| string  | string      | string   | string         |
 
 4. SENTENCE_SET_FEEDBACK_TABLE_NAME - Contains free text feedback given at the end of evaluating a set of sentences
 

--- a/src/DynamoDB/__tests__/dynamoDBApi.test.ts
+++ b/src/DynamoDB/__tests__/dynamoDBApi.test.ts
@@ -21,7 +21,7 @@ describe('getSentencePairScores', () => {
             score =>
               score.sentencePairId === '1' &&
               score.evaluatorId === '2' &&
-              score.score === 5
+              score.q1Score === 5
           ).length
         ).toEqual(1);
       });
@@ -42,7 +42,7 @@ describe('getSentencePairScores', () => {
             score.scoreId === '123' &&
             score.sentencePairId === 'undefined' &&
             score.evaluatorId === 'undefined' &&
-            score.score === 0
+            score.q1Score === 0
         ).length
       ).toEqual(1);
     });

--- a/src/DynamoDB/dynamoDBApi.ts
+++ b/src/DynamoDB/dynamoDBApi.ts
@@ -177,7 +177,7 @@ const getSentencePairScores = (
 
 const putSentencePairScore = (
   sentencePairId: string,
-  score: number,
+  q1Score: number,
   evaluatorId: string,
   client: DocumentClient = dynamoClient
 ): Promise<string> => {
@@ -186,7 +186,7 @@ const putSentencePairScore = (
     Item: {
       scoreId,
       sentencePairId,
-      score,
+      q1Score,
       evaluatorId,
     },
     TableName: getSentencePairScoresTableName(),

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -46,11 +46,11 @@ class SentencePairScore {
     public scoreId: string,
     public sentencePairId: string,
     public evaluatorId: string,
-    public score: number
+    public q1Score: number
   ) {}
 
   public convertToCSV(): string {
-    return `${this.scoreId}, ${this.sentencePairId}, ${this.evaluatorId}, ${this.score}`;
+    return `${this.scoreId}, ${this.sentencePairId}, ${this.evaluatorId}, ${this.q1Score}`;
   }
 }
 

--- a/src/models/requests.ts
+++ b/src/models/requests.ts
@@ -3,7 +3,7 @@ import { Request } from 'express';
 interface SentencePairEvaluationRequestBody {
   id: string;
   setId: string;
-  score: number;
+  q1Score: number;
   evaluatorId: string;
   numOfPracticeSentences: number;
   setSize: number;

--- a/src/routes/evaluation.ts
+++ b/src/routes/evaluation.ts
@@ -17,7 +17,7 @@ const buildEvaluationRoutes = (app: Application) => {
       const body: SentencePairEvaluationRequestBody = req.body;
       const id: string = body.id;
       const setId: string = body.setId;
-      const score: number = body.score;
+      const q1Score: number = body.q1Score;
       const evaluatorId: string = body.evaluatorId;
       const numOfPracticeSentences = body.numOfPracticeSentences || 0;
       const setSize = body.setSize || 0;
@@ -29,7 +29,7 @@ const buildEvaluationRoutes = (app: Application) => {
             1}&setSize=${setSize}&sentenceNum=${sentenceNum}`
         );
       } else {
-        putSentencePairScore(id, score, evaluatorId)
+        putSentencePairScore(id, q1Score, evaluatorId)
           .then(() =>
             res.redirect(
               `/evaluation?setId=${setId}&evaluatorId=${evaluatorId}&setSize=${setSize}&sentenceNum=${sentenceNum}`
@@ -37,7 +37,7 @@ const buildEvaluationRoutes = (app: Application) => {
           )
           .catch(error => {
             logger.error(
-              `Unable to put score for id: ${id}, score: ${score} and evaluatorId: ${evaluatorId}. Error${error}`
+              `Unable to put score for id: ${id}, score: ${q1Score} and evaluatorId: ${evaluatorId}. Error${error}`
             );
             res.redirect('/error?errorCode=postEvaluation');
           });

--- a/views/evaluation.hbs
+++ b/views/evaluation.hbs
@@ -68,7 +68,7 @@
                                       method="POST">
                                     <div class="row justify-content-center">
                                         <div class="col-sm-11">
-                                            <label for="score"
+                                            <label for="q1Score"
                                                    class="float-left">strongly disagree</label>
                                             <label for=""
                                                    class="float-right">strongly agree</label>
@@ -78,7 +78,7 @@
                                         <div class="col-sm-9">
                                             <input type="range"
                                                    class="evaluation__form__slider"
-                                                   name="score">
+                                                   name="q1Score">
                                         </div>
                                         <input type="hidden"
                                                name="id"


### PR DESCRIPTION
What's changed:

- Rename `score` to `q1Score` in sentence scores table in preparation for asking users to provide 2 scores rather than 1 for each sentence