### PR TITLE
Show which evaluators have completed each evaluation set

### DIFF
--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -68,6 +68,11 @@ class SentenceSetFeedback {
   ) {}
 }
 
+interface EvaluatorSet {
+  setName: string;
+  evaluators: string;
+}
+
 enum Language {
   BULGARIAN = 'bg',
   GUJARATI = 'gu',
@@ -83,4 +88,5 @@ export {
   Dataset,
   Language,
   SentenceSetFeedback,
+  EvaluatorSet,
 };

--- a/src/routes/__tests__/exportData.test.ts
+++ b/src/routes/__tests__/exportData.test.ts
@@ -1,7 +1,12 @@
 import * as supertest from 'supertest';
 import app from '../../app';
 import { SuperTest, Test } from 'supertest';
-import { SentencePairScore, SentenceSetFeedback } from '../../models/models';
+import {
+  SentencePairScore,
+  SentenceSetFeedback,
+  SentenceSet,
+  Language,
+} from '../../models/models';
 import { generateLanguageOptions } from '../exportData';
 
 jest.mock('../../DynamoDB/dynamoDBApi');
@@ -14,6 +19,18 @@ describe('GET /exportData', () => {
   });
 
   test('should return 200', async () => {
+    dynamoDBApi.getSentenceSets.mockImplementation(() => {
+      return Promise.resolve([
+        new SentenceSet(
+          'name',
+          Language.BULGARIAN,
+          Language.ENGLISH,
+          new Set(),
+          'setId',
+          new Set()
+        ),
+      ]);
+    });
     const response = await mockApp.get('/exportData');
     expect(response.status).toBe(200);
   });

--- a/views/exportData.hbs
+++ b/views/exportData.hbs
@@ -34,6 +34,19 @@
                             <h1 class="text-center text-primary-mid-green">Export Data and Feedback</h1>
                             <h2 class="text-center text-primary-dark-grey">Downloads may take a few minutes depending on
                                 the size of the data set.</h2>
+                            <div class="row margin-top-5percent">
+                                <h4>Current Evaluators:</h4>
+                                <div class="row">
+                                    {{#each evaluatorSets}}
+                                    <div class="col-sm-3">
+                                        {{this.setName}}:
+                                    </div>
+                                    <div class="col-sm-9">
+                                        <p>{{this.evaluators}}</p>
+                                    </div>
+                                    {{/each}}
+                                </div>
+                            </div>
                         </div>
                     </div>
                     <div class="row justify-content-center margin-top-5percent">


### PR DESCRIPTION
What's changed:
- The export data page now also shows the evaluators who have completed each evaluation set
![image](https://user-images.githubusercontent.com/6666113/76616692-813d7680-651c-11ea-871b-393d9da6e505.png)
