### PR TITLE
feat: remove duplicate answers with the same evaluatorId

### DIFF
--- a/src/DynamoDB/dynamoDBApi.ts
+++ b/src/DynamoDB/dynamoDBApi.ts
@@ -306,7 +306,8 @@ const convertAttributeMapToSentencePairScore = (
     item['machineTranslation'] || 'undefined',
     item['original'] || 'undefined',
     item['sentencePairType'] || 'A',
-    item['scoreId'] || 'undefined'
+    item['scoreId'] || 'undefined',
+    Number(item['timestamp'] || -1)
   );
 };
 

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -44,6 +44,7 @@ class SentencePair {
 }
 
 class SentencePairScore {
+  public timestamp: number;
   constructor(
     public sentencePairId: string,
     public evaluatorId: string,
@@ -54,9 +55,11 @@ class SentencePairScore {
     public machineTranslation: string,
     public original: string,
     public sentencePairType: string,
-    public scoreId?: string
+    public scoreId?: string,
+    timestamp?: number
   ) {
     this.scoreId = scoreId === undefined ? uuidv1() : scoreId;
+    this.timestamp = timestamp === undefined ? -1 : timestamp;
   }
 }
 

--- a/src/routes/__tests__/exportData.test.ts
+++ b/src/routes/__tests__/exportData.test.ts
@@ -7,7 +7,7 @@ import {
   SentenceSet,
   Language,
 } from '../../models/models';
-import { generateLanguageOptions } from '../exportData';
+import { generateLanguageOptions, removeDuplicateAnswers } from '../exportData';
 
 jest.mock('../../DynamoDB/dynamoDBApi');
 const dynamoDBApi = require('../../DynamoDB/dynamoDBApi');
@@ -161,5 +161,80 @@ describe('generateLanguageOptions', () => {
     ];
 
     expect(generateLanguageOptions()).toEqual(expectedResponse);
+  });
+});
+
+describe('removeDuplicateAnswers', () => {
+  test('should remove newer duplicate answers created with the same evaluatorId', () => {
+    const sentencePair1ScoreDuplicate = new SentencePairScore(
+      'sentenceId1',
+      'evaluatorId1',
+      100,
+      40,
+      'target',
+      'humanTranslation',
+      'machineTranslation',
+      'original',
+      'type',
+      'scoreId',
+      200
+    );
+
+    const sentencePair1ScoreEarliest = new SentencePairScore(
+      'sentenceId1',
+      'evaluatorId1',
+      100,
+      40,
+      'target',
+      'humanTranslation',
+      'machineTranslation',
+      'original',
+      'type',
+      'scoreId',
+      100
+    );
+
+    const sentencePair1Score = new SentencePairScore(
+      'sentenceId1',
+      'evaluatorId2',
+      70,
+      40,
+      'target',
+      'humanTranslation',
+      'machineTranslation',
+      'original',
+      'type',
+      'scoreId',
+      123
+    );
+
+    const sentencePair2Score = new SentencePairScore(
+      'sentenceId2',
+      'evaluatorId1',
+      90,
+      30,
+      'target',
+      'humanTranslation',
+      'machineTranslation',
+      'original',
+      'type',
+      'scoreId',
+      100
+    );
+
+    const sentencePairsScores = [
+      sentencePair1ScoreDuplicate,
+      sentencePair1ScoreEarliest,
+      sentencePair1Score,
+      sentencePair2Score,
+    ];
+
+    const expectedResult = [
+      sentencePair1ScoreEarliest,
+      sentencePair1Score,
+      sentencePair2Score,
+    ];
+
+    expect(removeDuplicateAnswers(sentencePairsScores)).toEqual(expectedResult);
   });
 });


### PR DESCRIPTION
Problem: some evaluators accidentally evaluate the same sentence more than once. If this happens when exporting data we should only export the sentence with the earliest timestamp
- segment answers are sorted and duplicates with later timestamps are removed
