### PR TITLE
feat: remove language enum and checks

### DIFF
--- a/docs/users.md
+++ b/docs/users.md
@@ -20,6 +20,8 @@ The Data set must be a json file with the following structure:
 ```
 {
     "possibleEvaluatorIds": list[string],
+    "sourceLanguage": string,
+    "targetLanguage": string,
     "sentences": list[Sentences]
 }
 ```
@@ -39,28 +41,30 @@ For Example:
 
 ```json
 {
-    "possibleEvaluatorIds": ["evaluator1", "evaluator2"],
-    "sentences": [
-        {
-            "original": "Only a few weeks ago, Andrei Vaganov and Yevgeny Yerofeyev had no problem with the Russian authorities.",
-            "humanTranslation": "Допреди няколко седмици Андрей Ваганов и Евгений Ерофеев нямали проблеми с руските власти.",
-            "machineTranslation": "Само преди няколко седмици Андрей Ваганов и Евгений Йерфеев нямаха проблем с руските власти.",
-            "sentencePairType": "A"
-        },
-        {
-            "original": "The couple had married in Denmark and lived with their two adopted sons in Moscow.",
-            "humanTranslation": "Двамата се оженили в Дания и заживели с двамата си осиновени синове в Москва.",
-            "machineTranslation": "Двойката е омъжена в Дания и живее с двамата си осиновени синове в Москва.",
-            "sentencePairType": "A"
-        }
-    ]
+  "possibleEvaluatorIds": ["evaluator1", "evaluator2"],
+  "sourceLanguage": "English",
+  "targetLanguage": "Bulgarian",
+  "sentences": [
+    {
+      "original": "Only a few weeks ago, Andrei Vaganov and Yevgeny Yerofeyev had no problem with the Russian authorities.",
+      "humanTranslation": "Допреди няколко седмици Андрей Ваганов и Евгений Ерофеев нямали проблеми с руските власти.",
+      "machineTranslation": "Само преди няколко седмици Андрей Ваганов и Евгений Йерфеев нямаха проблем с руските власти.",
+      "sentencePairType": "A"
+    },
+    {
+      "original": "The couple had married in Denmark and lived with their two adopted sons in Moscow.",
+      "humanTranslation": "Двамата се оженили в Дания и заживели с двамата си осиновени синове в Москва.",
+      "machineTranslation": "Двойката е омъжена в Дания и живее с двамата си осиновени синове в Москва.",
+      "sentencePairType": "A"
+    }
+  ]
 }
 ```
 
 Parts of the data structure:
 
 - possibleEvaluatorIds: A participant will select an evaluator ID when starting the Direct Assessment exercise. This determines the list of evaluator IDs that will be available for a given data set. The Tool will always provide the evaluator ID 'tester'. This is used for testing purposes and should not be used by an actual participant as their scores will not be shown in the results
-- sentencePairType: A way to mark sentences of different types. For example if as the Evaluation Coordinator you wanted to introduce some nonsense sentences or perfect translations to use as a benchmark. 
+- sentencePairType: A way to mark sentences of different types. For example if as the Evaluation Coordinator you wanted to introduce some nonsense sentences or perfect translations to use as a benchmark.
 
 At the BBC data set JSON is generated using the [`randomiseAndFormatData.py`](../scripts/randomiseAndFormatData.py) script. The comments in the [script](../scripts/randomiseAndFormatData.py) document how to use it. The [exampleData directory](../scripts/exampleData) provides examples of input and output. While this script is specific to the way the BBC uses the Direct Assessment Tool for evaluation the script can be adapted and generalised to fit other use cases.
 

--- a/src/DynamoDB/__tests__/dynamoDBApi.test.ts
+++ b/src/DynamoDB/__tests__/dynamoDBApi.test.ts
@@ -9,7 +9,7 @@ import {
 import { DocumentClient } from 'aws-sdk/clients/dynamodb';
 
 import '../../config';
-import { SentencePairScore, Language, SentenceSet } from '../../models/models';
+import { SentencePairScore, SentenceSet } from '../../models/models';
 
 const config = {
   convertEmptyValues: true,
@@ -22,58 +22,34 @@ const mockDynamoClient = new DocumentClient(config);
 
 describe('getSentenceSetFeedback', () => {
   beforeAll(() => {
-    return putSentenceSetFeedback(
-      '1',
-      'good',
-      '1',
-      Language.BULGARIAN,
-      mockDynamoClient
-    )
+    return putSentenceSetFeedback('1', 'good', '1', 'bg', mockDynamoClient)
       .then(_ =>
-        putSentenceSetFeedback(
-          '2',
-          'good',
-          '1',
-          Language.BULGARIAN,
-          mockDynamoClient
-        )
+        putSentenceSetFeedback('2', 'good', '1', 'bg', mockDynamoClient)
       )
       .then(_ => {
-        putSentenceSetFeedback(
-          '2',
-          'good',
-          'tester',
-          Language.GUJARATI,
-          mockDynamoClient
-        );
+        putSentenceSetFeedback('2', 'good', 'tester', 'gu', mockDynamoClient);
       });
   });
 
   test('should only retrieve feedback with the requested target language', () => {
-    return getSentenceSetFeedback(Language.BULGARIAN, mockDynamoClient).then(
-      scores => {
-        expect(scores.length).toEqual(2);
-        expect(scores.filter(score => score.setId === '1').length).toEqual(1);
-      }
-    );
+    return getSentenceSetFeedback('bg', mockDynamoClient).then(scores => {
+      expect(scores.length).toEqual(2);
+      expect(scores.filter(score => score.setId === '1').length).toEqual(1);
+    });
   });
 
   test('should not retrieve feedback where the evaluatorId is tester', () => {
-    return getSentenceSetFeedback(Language.GUJARATI, mockDynamoClient).then(
-      scores => {
-        expect(
-          scores.filter(score => score.evaluatorId === 'tester').length
-        ).toEqual(0);
-      }
-    );
+    return getSentenceSetFeedback('gu', mockDynamoClient).then(scores => {
+      expect(
+        scores.filter(score => score.evaluatorId === 'tester').length
+      ).toEqual(0);
+    });
   });
 
   test('should return an empty list if there is no feedback for a specified language', () => {
-    return getSentenceSetFeedback(Language.SWAHILI, mockDynamoClient).then(
-      scores => {
-        expect(scores.length).toEqual(0);
-      }
-    );
+    return getSentenceSetFeedback('sw', mockDynamoClient).then(scores => {
+      expect(scores.length).toEqual(0);
+    });
   });
 
   test('should handle items with missing parameters', async () => {
@@ -83,20 +59,18 @@ describe('getSentenceSetFeedback', () => {
         TableName: 'SentenceSetFeedbackDynamoDBTable-local-dev',
       })
       .promise();
-    return getSentenceSetFeedback(Language.BULGARIAN, mockDynamoClient).then(
-      scores => {
-        expect(
-          scores.filter(
-            score =>
-              score.feedbackId === '123' &&
-              score.targetLanguage === 'BG' &&
-              score.feedback === 'undefined' &&
-              score.evaluatorId === 'undefined' &&
-              score.setId === 'undefined'
-          ).length
-        ).toEqual(1);
-      }
-    );
+    return getSentenceSetFeedback('bg', mockDynamoClient).then(scores => {
+      expect(
+        scores.filter(
+          score =>
+            score.feedbackId === '123' &&
+            score.targetLanguage === 'BG' &&
+            score.feedback === 'undefined' &&
+            score.evaluatorId === 'undefined' &&
+            score.setId === 'undefined'
+        ).length
+      ).toEqual(1);
+    });
   });
 });
 
@@ -161,50 +135,42 @@ describe('getSentencePairScores', () => {
   });
 
   test('should only retrieve scores put into the DB with the requested language', () => {
-    return getSentencePairScores(Language.BULGARIAN, mockDynamoClient).then(
-      scores => {
-        expect(scores.length).toEqual(2);
-      }
-    );
+    return getSentencePairScores('bg', mockDynamoClient).then(scores => {
+      expect(scores.length).toEqual(2);
+    });
   });
 
   test('should retrieve scores put into the DB', () => {
-    return getSentencePairScores(Language.BULGARIAN, mockDynamoClient).then(
-      scores => {
-        expect(
-          scores.filter(
-            score =>
-              score.sentencePairId === '1' &&
-              score.evaluatorId === '2' &&
-              score.q1Score === 5 &&
-              score.targetLanguage === 'BG' &&
-              score.humanTranslation === 'human' &&
-              score.machineTranslation === 'machine' &&
-              score.original === 'original' &&
-              score.sentencePairType === 'A' &&
-              score.scoreId === '10'
-          ).length
-        ).toEqual(1);
-      }
-    );
+    return getSentencePairScores('bg', mockDynamoClient).then(scores => {
+      expect(
+        scores.filter(
+          score =>
+            score.sentencePairId === '1' &&
+            score.evaluatorId === '2' &&
+            score.q1Score === 5 &&
+            score.targetLanguage === 'BG' &&
+            score.humanTranslation === 'human' &&
+            score.machineTranslation === 'machine' &&
+            score.original === 'original' &&
+            score.sentencePairType === 'A' &&
+            score.scoreId === '10'
+        ).length
+      ).toEqual(1);
+    });
   });
 
   test('should not retrieve scores where the evaluatorId is tester', () => {
-    return getSentencePairScores(Language.GUJARATI, mockDynamoClient).then(
-      scores => {
-        expect(
-          scores.filter(score => score.evaluatorId === 'tester').length
-        ).toEqual(0);
-      }
-    );
+    return getSentencePairScores('gu', mockDynamoClient).then(scores => {
+      expect(
+        scores.filter(score => score.evaluatorId === 'tester').length
+      ).toEqual(0);
+    });
   });
 
   test('should return an empty list if there are no scores for a specified language', () => {
-    return getSentencePairScores(Language.SWAHILI, mockDynamoClient).then(
-      scores => {
-        expect(scores.length).toEqual(0);
-      }
-    );
+    return getSentencePairScores('sw', mockDynamoClient).then(scores => {
+      expect(scores.length).toEqual(0);
+    });
   });
 
   test('should handle items with missing parameters', async () => {
@@ -214,31 +180,29 @@ describe('getSentencePairScores', () => {
         TableName: 'SentenceScoreDynamoDBTable-local-dev',
       })
       .promise();
-    return getSentencePairScores(Language.BULGARIAN, mockDynamoClient).then(
-      scores => {
-        expect(
-          scores.filter(
-            score =>
-              score.scoreId === '123' &&
-              score.targetLanguage === 'BG' &&
-              score.sentencePairId === 'undefined' &&
-              score.evaluatorId === 'undefined' &&
-              score.q1Score === 0 &&
-              score.humanTranslation === 'undefined' &&
-              score.machineTranslation === 'undefined' &&
-              score.original === 'undefined' &&
-              score.sentencePairType === 'A'
-          ).length
-        ).toEqual(1);
-      }
-    );
+    return getSentencePairScores('bg', mockDynamoClient).then(scores => {
+      expect(
+        scores.filter(
+          score =>
+            score.scoreId === '123' &&
+            score.targetLanguage === 'BG' &&
+            score.sentencePairId === 'undefined' &&
+            score.evaluatorId === 'undefined' &&
+            score.q1Score === 0 &&
+            score.humanTranslation === 'undefined' &&
+            score.machineTranslation === 'undefined' &&
+            score.original === 'undefined' &&
+            score.sentencePairType === 'A'
+        ).length
+      ).toEqual(1);
+    });
   });
 });
 
 describe('putSentenceSet', () => {
   test('should populate the list of possible evaluator Ids with tester if the set of evaluator Ids is empty', () => {
     return putSentenceSet(
-      new SentenceSet('name', Language.BULGARIAN, Language.ENGLISH, new Set()),
+      new SentenceSet('name', 'bg', 'en', new Set()),
       mockDynamoClient
     ).then(id => {
       return getSentenceSet(id, mockDynamoClient).then(sentenceSet => {

--- a/src/DynamoDB/dynamoDBApi.ts
+++ b/src/DynamoDB/dynamoDBApi.ts
@@ -3,7 +3,6 @@ import {
   SentencePair,
   SentenceSet,
   SentencePairScore,
-  Language,
   SentenceSetFeedback,
 } from '../models/models';
 import * as uuidv1 from 'uuid/v1';
@@ -77,8 +76,8 @@ const getSentenceSet = (
 const putSentenceSetAndPairs = (
   sentencePairs: SentencePair[],
   setName: string,
-  sourceLanguage: Language,
-  targetLanguage: Language,
+  sourceLanguage: string,
+  targetLanguage: string,
   possibleEvaluatorIds: string[],
   setId?: string
 ): Promise<string> => {
@@ -175,7 +174,7 @@ const putSentencePair = (
 };
 
 const getSentencePairScores = (
-  targetLanguage: Language,
+  targetLanguage: string,
   client: DocumentClient = dynamoClient
 ): Promise<SentencePairScore[]> => {
   return client
@@ -227,7 +226,7 @@ const putSentencePairScore = (
 };
 
 const getSentenceSetFeedback = (
-  targetLanguage: Language,
+  targetLanguage: string,
   client: DocumentClient = dynamoClient
 ): Promise<SentenceSetFeedback[]> => {
   return client

--- a/src/__tests__/processDataset.test.ts
+++ b/src/__tests__/processDataset.test.ts
@@ -1,5 +1,5 @@
 import { cleanData, submitDataset } from '../processDataset';
-import { Dataset, Language } from '../models/models';
+import { Dataset } from '../models/models';
 import { DatasetBody, DatasetFile, DatasetSentence } from '../models/requests';
 import { Some, None } from '../models/generics';
 
@@ -24,112 +24,12 @@ describe('cleanData', () => {
     const file: DatasetFile = {
       possibleEvaluatorIds: ['tester'],
       sentences: [sentence],
+      sourceLanguage: 'en',
+      targetLanguage: 'bg',
     };
-    const expectedDataset: Dataset = new Dataset(
-      [sentence],
-      '',
-      Language.ENGLISH,
-      Language.BULGARIAN,
-      ['tester']
-    );
-    const expectedOutput = new Some(expectedDataset);
-    expect(cleanData(input, file)).toEqual(expectedOutput);
-  });
-
-  test("should return None if the source language is not defined in the 'Language' enum", () => {
-    const input: DatasetBody = {
-      setName: '',
-      sourceLanguage: 'GREEK',
-      targetLanguage: 'BULGARIAN',
-    };
-    const sentence: DatasetSentence = {
-      original: 'Sentence1',
-      humanTranslation: 'human',
-      machineTranslation: 'machine',
-      sentencePairType: 'A',
-    };
-
-    const file: DatasetFile = {
-      possibleEvaluatorIds: ['tester'],
-      sentences: [sentence],
-    };
-    const expectedOutput = new None();
-    expect(cleanData(input, file)).toEqual(expectedOutput);
-  });
-
-  test("should return None if the target language is not defined in the 'Language' enum", () => {
-    const input: DatasetBody = {
-      setName: '',
-      sourceLanguage: 'ENGLISH',
-      targetLanguage: 'GREEK',
-    };
-    const sentence: DatasetSentence = {
-      original: 'Sentence1',
-      humanTranslation: 'human',
-      machineTranslation: 'machine',
-      sentencePairType: 'A',
-    };
-
-    const file: DatasetFile = {
-      possibleEvaluatorIds: ['tester'],
-      sentences: [sentence],
-    };
-    const expectedOutput = new None();
-    expect(cleanData(input, file)).toEqual(expectedOutput);
-  });
-
-  test('should not fail if the source language is lower case', () => {
-    const input: DatasetBody = {
-      setName: '',
-      sourceLanguage: 'english',
-      targetLanguage: 'BULGARIAN',
-    };
-    const sentence: DatasetSentence = {
-      original: 'Sentence1',
-      humanTranslation: 'human',
-      machineTranslation: 'machine',
-      sentencePairType: 'A',
-    };
-
-    const file: DatasetFile = {
-      possibleEvaluatorIds: ['tester'],
-      sentences: [sentence],
-    };
-    const expectedDataset: Dataset = new Dataset(
-      [sentence],
-      '',
-      Language.ENGLISH,
-      Language.BULGARIAN,
-      ['tester']
-    );
-    const expectedOutput = new Some(expectedDataset);
-    expect(cleanData(input, file)).toEqual(expectedOutput);
-  });
-
-  test('should not fail if the target language is lower case', () => {
-    const input: DatasetBody = {
-      setName: '',
-      sourceLanguage: 'ENGLISH',
-      targetLanguage: 'bulgarian',
-    };
-    const sentence: DatasetSentence = {
-      original: 'Sentence1',
-      humanTranslation: 'human',
-      machineTranslation: 'machine',
-      sentencePairType: 'A',
-    };
-
-    const file: DatasetFile = {
-      sentences: [sentence],
-      possibleEvaluatorIds: ['tester'],
-    };
-    const expectedDataset: Dataset = new Dataset(
-      [sentence],
-      '',
-      Language.ENGLISH,
-      Language.BULGARIAN,
-      ['tester']
-    );
+    const expectedDataset: Dataset = new Dataset([sentence], '', 'en', 'bg', [
+      'tester',
+    ]);
     const expectedOutput = new Some(expectedDataset);
     expect(cleanData(input, file)).toEqual(expectedOutput);
   });
@@ -157,15 +57,13 @@ describe('submitDataset', () => {
 
     const file: DatasetFile = {
       sentences: [sentence],
+      sourceLanguage: 'en',
+      targetLanguage: 'bg',
       possibleEvaluatorIds: ['tester'],
     };
 
     const mockCleaningFunction = (body: DatasetBody, file: DatasetFile) =>
-      new Some(
-        new Dataset([sentence], '', Language.BULGARIAN, Language.BULGARIAN, [
-          'tester',
-        ])
-      );
+      new Some(new Dataset([sentence], '', 'bg', 'bg', ['tester']));
 
     return submitDataset(input, file, mockCleaningFunction).then(id => {
       expect(id).toEqual(datasetIDInDB);
@@ -194,6 +92,8 @@ describe('submitDataset', () => {
 
     const file: DatasetFile = {
       sentences: [sentence],
+      sourceLanguage: 'en',
+      targetLanguage: 'bg',
       possibleEvaluatorIds: ['tester'],
     };
 
@@ -235,6 +135,8 @@ describe('submitDataset', () => {
 
     const file: DatasetFile = {
       sentences: [sentence],
+      sourceLanguage: 'en',
+      targetLanguage: 'bg',
       possibleEvaluatorIds: ['tester'],
     };
 

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -5,8 +5,8 @@ class Dataset {
   constructor(
     public sentences: DatasetSentence[],
     public setName: string,
-    public sourceLanguage: Language,
-    public targetLanguage: Language,
+    public sourceLanguage: string,
+    public targetLanguage: string,
     public possibleEvaluatorIds: string[]
   ) {}
 }
@@ -16,8 +16,8 @@ class SentenceSet {
 
   constructor(
     public name: string,
-    public sourceLanguage: Language,
-    public targetLanguage: Language,
+    public sourceLanguage: string,
+    public targetLanguage: string,
     public possibleEvaluatorIds: Set<string>,
     public sentenceIds?: Set<string>,
     setId?: string,
@@ -34,8 +34,8 @@ class SentencePair {
     public original: string,
     public humanTranslation: string,
     public machineTranslation: string,
-    public sourceLanguage: Language,
-    public targetLanguage: Language,
+    public sourceLanguage: string,
+    public targetLanguage: string,
     public sentencePairType: string,
     sentenceId?: string
   ) {
@@ -76,14 +76,7 @@ class SentenceSetFeedback {
 interface EvaluatorSet {
   setName: string;
   evaluators: string;
-}
-
-enum Language {
-  BULGARIAN = 'bg',
-  GUJARATI = 'gu',
-  SWAHILI = 'sw',
-  TURKISH = 'tr',
-  ENGLISH = 'en',
+  targetLanguage: string;
 }
 
 export {
@@ -91,7 +84,6 @@ export {
   SentencePair,
   SentencePairScore,
   Dataset,
-  Language,
   SentenceSetFeedback,
   EvaluatorSet,
 };

--- a/src/models/requests.ts
+++ b/src/models/requests.ts
@@ -50,6 +50,8 @@ interface DatasetBody {
 
 interface DatasetFile {
   possibleEvaluatorIds: string[];
+  targetLanguage: string;
+  sourceLanguage: string;
   sentences: DatasetSentence[];
 }
 

--- a/src/processDataset.ts
+++ b/src/processDataset.ts
@@ -1,4 +1,4 @@
-import { Dataset, SentencePair, Language } from './models/models';
+import { Dataset, SentencePair } from './models/models';
 import { putSentenceSetAndPairs } from './DynamoDB/dynamoDBApi';
 import { DatasetBody, DatasetFile } from './models/requests';
 import { Some, None, Option } from './models/generics';
@@ -10,19 +10,16 @@ const cleanData = (
   dataset: DatasetBody,
   datasetFile: DatasetFile
 ): Option<Dataset> => {
-  const sourceLanguage: Language = (Language as any)[
-    dataset.sourceLanguage.toUpperCase()
-  ];
-  const targetLanguage: Language = (Language as any)[
-    dataset.targetLanguage.toUpperCase()
-  ];
-  if (targetLanguage !== undefined && sourceLanguage !== undefined) {
+  if (
+    datasetFile.targetLanguage !== undefined &&
+    datasetFile.sourceLanguage !== undefined
+  ) {
     return new Some(
       new Dataset(
         datasetFile.sentences,
         dataset.setName,
-        sourceLanguage,
-        targetLanguage,
+        datasetFile.sourceLanguage,
+        datasetFile.targetLanguage,
         datasetFile.possibleEvaluatorIds
       )
     );

--- a/src/routes/__tests__/exportData.test.ts
+++ b/src/routes/__tests__/exportData.test.ts
@@ -5,9 +5,8 @@ import {
   SentencePairScore,
   SentenceSetFeedback,
   SentenceSet,
-  Language,
 } from '../../models/models';
-import { generateLanguageOptions, removeDuplicateAnswers } from '../exportData';
+import { removeDuplicateAnswers } from '../exportData';
 
 jest.mock('../../DynamoDB/dynamoDBApi');
 const dynamoDBApi = require('../../DynamoDB/dynamoDBApi');
@@ -23,8 +22,8 @@ describe('GET /exportData', () => {
       return Promise.resolve([
         new SentenceSet(
           'name',
-          Language.BULGARIAN,
-          Language.ENGLISH,
+          'bg',
+          'en',
           new Set(),
           new Set(),
           'setId',
@@ -73,9 +72,7 @@ describe('POST /exportData', () => {
       ]);
     });
 
-    const response = await mockApp
-      .post('/exportData')
-      .send({ language: 'SWAHILI' });
+    const response = await mockApp.post('/exportData').send({ language: 'sw' });
     expect(response.status).toBe(200);
     expect(response.header['content-disposition']).toEqual(
       'attachment; filename="sw.zip"'
@@ -137,30 +134,6 @@ describe('POST /exportData', () => {
     expect(response.header['location']).toEqual(
       '/error?errorCode=postExportDataFailCSVCreate'
     );
-  });
-
-  test('should redirect to the error page with a 404 if the language value sent is not valid', async () => {
-    const response = await mockApp
-      .post('/exportData')
-      .send({ language: 'FAKE' });
-    expect(response.status).toBe(404);
-    expect(response.header['location']).toEqual(
-      '/error?errorCode=postExportFailLanguage'
-    );
-  });
-});
-
-describe('generateLanguageOptions', () => {
-  test('should return a list with an object for all language options available according to the Language enum', () => {
-    const expectedResponse = [
-      { displayName: 'Bulgarian', language: 'BULGARIAN' },
-      { displayName: 'Gujarati', language: 'GUJARATI' },
-      { displayName: 'Swahili', language: 'SWAHILI' },
-      { displayName: 'Turkish', language: 'TURKISH' },
-      { displayName: 'English', language: 'ENGLISH' },
-    ];
-
-    expect(generateLanguageOptions()).toEqual(expectedResponse);
   });
 });
 

--- a/src/routes/dataset.ts
+++ b/src/routes/dataset.ts
@@ -1,7 +1,6 @@
 import { Request, Response, Application } from 'express';
 import { DatasetBody, DatasetFile, DatasetRequest } from '../models/requests';
 import { submitDataset } from '../processDataset';
-import { Language } from '../models/models';
 import { readFileSync, unlink } from 'fs';
 import { Instance } from 'multer';
 import { logger } from '../utils/logger';
@@ -51,17 +50,7 @@ const buildDatasetRoutes = (app: Application, upload: Instance) => {
   );
 
   app.get('/dataset', (req: Request, res: Response) => {
-    const languages = Object.keys(Language);
-    // Get all possible values for Language enum
-    const languageOptions = languages.map(languageName => {
-      return {
-        displayName:
-          languageName.charAt(0).toUpperCase() +
-          languageName.slice(1).toLowerCase(),
-        language: languageName,
-      };
-    });
-    res.render('dataset', { languageOptions });
+    res.render('dataset');
   });
 };
 

--- a/views/dataset.hbs
+++ b/views/dataset.hbs
@@ -1,110 +1,77 @@
-
 <!DOCTYPE html>
 <html>
 
-    <head>
-        <link rel="shortcut icon"
-              href="media/favicon.ico"
-              type="image/x-icon" />
-        <!-- Adding bootstrap CSS styles -->
-        <link rel="stylesheet"
-              href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
-              integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T"
-              crossorigin="anonymous">
+<head>
+    <link rel="shortcut icon" href="media/favicon.ico" type="image/x-icon" />
+    <!-- Adding bootstrap CSS styles -->
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
+        integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
 
-        <meta charset="utf-8">
-        <meta name="viewport"
-              content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-        <title>Sentence Pairs</title>
-        <link rel="stylesheet"
-              type="text/css"
-              href="main.css" />
-    </head>
+    <title>Sentence Pairs</title>
+    <link rel="stylesheet" type="text/css" href="main.css" />
+</head>
 
-    <body class="bg-grey">
-        <div>
-            <img class="gourmet_logo"
-                 src="./media/horizontal_light.png" />
-        </div>
-        <div class="container">
-            <div class="row justify-content-center">
-                <div class="col-sm-10 text-primary-dark-grey">
-                    <h1 class="text-center text-primary-mid-green">Text for Evaluation</h1>
-                    <p class="margin-top-5percent">This page is for submission of data sets to be evaluated. The user
-                        MUST give a name for the sentence set as well as the source language and target language. This
-                        name will be given to evaluators to identify the data set they should analyse. The file provided
-                        MUST be a json file containing JSON of the following form:
-                    </p>
-                    <p>
-                        {
-                        "possibleEvaluatorIds": list[string],
-                        "sentences": list[Sentences]
-                        }
-                    </p>
-                    <p>
-                        Where Sentences is of type:
-                    </p>
-                    <p>
-                        {
-                        "original": string,
-                        "humanTranslation": string,
-                        "machineTranslation": string,
-                        "sentencePairType: string
-                        }
-                    </p>
-                    <form action="/dataset"
-                          method="POST"
-                          enctype="multipart/form-data">
-                        <div class="form-row">
-                            <div class="form-group col-md-4">
+<body class="bg-grey">
+    <div>
+        <img class="gourmet_logo" src="./media/horizontal_light.png" />
+    </div>
+    <div class="container">
+        <div class="row justify-content-center">
+            <div class="col-sm-10 text-primary-dark-grey">
+                <h1 class="text-center text-primary-mid-green">Text for Evaluation</h1>
+                <p class="margin-top-5percent">This page is for submission of data sets to be evaluated. The user
+                    MUST give a name for the sentence set as well as the source language and target language. This
+                    name will be given to evaluators to identify the data set they should analyse. The file provided
+                    MUST be a json file containing JSON of the following form:
+                </p>
+                <p>
+                <pre><code>
+                    {
+                    "possibleEvaluatorIds": list[string],
+                    "sourceLanguage": string,
+                    "targetLanguage": string,
+                    "sentences": list[Sentences]
+                    }
+                    </code>
+                    </pre>
+                </p>
+                <p>
+                    Where Sentences is of type:
+                </p>
+                <p>
+                <pre><code>
+                    {
+                    "original": string,
+                    "humanTranslation": string,
+                    "machineTranslation": string,
+                    "sentencePairType": string
+                    }
+                    </code></pre>
+                </p>
+                <form action="/dataset" method="POST" enctype="multipart/form-data">
+                    <div class="form-row">
+                        <div class="form-group col-md-4">
 
-                                <label for="setName">Name of Sentence Set</label>
-                                <input class="form-control"
-                                       name="setName"
-                                       id="setName"
-                                       required></input>
-                            </div>
-                            <div class="form-group col-md-4">
-                                <label for="sourceLanguage">Source Language:</label>
-                                <select class="form-control"
-                                        name="sourceLanguage"
-                                        required>
-                                    <option></option>
-                                    {{#each languageOptions}}
-                                    <option value={{this.language}}>{{this.displayName}}</option>
-                                    {{/each}}
-                                </select>
-                            </div>
-                            <div class="form-group col-md-4">
-                                <label for="targetLanguage">Target Language:</label>
-                                <select class="form-control"
-                                        name="targetLanguage"
-                                        required>
-                                    <option></option>
-                                    {{#each languageOptions}}
-                                    <option value={{this.language}}>{{this.displayName}}</option>
-                                    {{/each}}
-                                </select>
-                            </div>
+                            <label for="setName">Name of Sentence Set</label>
+                            <input class="form-control" name="setName" id="setName" required></input>
                         </div>
-                        <div class="form-group">
-                            <label for="sentences">Choose file</label>
-                            <input type="file"
-                                   class="form-control-file"
-                                   name="sentences"
-                                   required>
+                    </div>
+                    <div class="form-group">
+                        <label for="sentences">Choose file</label>
+                        <input type="file" class="form-control-file" name="sentences" required>
+                    </div>
+                    <div class="form-row justify-content-center">
+                        <div class="form-group col-md-2">
+                            <button type="submit" class="btn button-primary btn-block">Submit</button>
                         </div>
-                        <div class="form-row justify-content-center">
-                            <div class="form-group col-md-2">
-                                <button type="submit"
-                                        class="btn button-primary btn-block">Submit</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
+                    </div>
+                </form>
             </div>
         </div>
-    </body>
+    </div>
+</body>
 
 </html>

--- a/views/exportData.hbs
+++ b/views/exportData.hbs
@@ -1,78 +1,66 @@
 <!DOCTYPE html>
 <html>
 
-    <head>
-        <link rel="shortcut icon"
-              href="media/favicon.ico"
-              type="image/x-icon" />
-        <!-- Adding bootstrap CSS styles -->
-        <link rel="stylesheet"
-              href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
-              integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T"
-              crossorigin="anonymous">
+<head>
+    <link rel="shortcut icon" href="media/favicon.ico" type="image/x-icon" />
+    <!-- Adding bootstrap CSS styles -->
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
+        integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
 
-        <meta charset="utf-8">
-        <meta name="viewport"
-              content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-        <title>Sentence Pairs</title>
-        <link rel="stylesheet"
-              type="text/css"
-              href="main.css" />
-    </head>
+    <title>Sentence Pairs</title>
+    <link rel="stylesheet" type="text/css" href="main.css" />
+</head>
 
-    <body class="bg-grey">
-        <div>
-            <img class="gourmet_logo"
-                 src="./media/horizontal_light.png" />
-        </div>
-        <div class="container">
-            <div class="row align-items-center">
-                <div class="col">
-                    <div class="row">
-                        <div class="col">
-                            <h1 class="text-center text-primary-mid-green">Export Data and Feedback</h1>
-                            <h2 class="text-center text-primary-dark-grey">Downloads may take a few minutes depending on
-                                the size of the data set.</h2>
-                            <div class="row margin-top-5percent">
-                                <h4>Current Evaluators:</h4>
-                                <div class="row">
-                                    {{#each evaluatorSets}}
-                                    <div class="col-sm-3">
-                                        {{this.setName}}:
-                                    </div>
-                                    <div class="col-sm-9">
-                                        <p>{{this.evaluators}}</p>
-                                    </div>
-                                    {{/each}}
+<body class="bg-grey">
+    <div>
+        <img class="gourmet_logo" src="./media/horizontal_light.png" />
+    </div>
+    <div class="container">
+        <div class="row align-items-center">
+            <div class="col">
+                <div class="row">
+                    <div class="col">
+                        <h1 class="text-center text-primary-mid-green">Export Data and Feedback</h1>
+                        <h2 class="text-center text-primary-dark-grey">Downloads may take a few minutes depending on
+                            the size of the data set.</h2>
+                        <div class="row margin-top-5percent">
+                            <h4>Current Evaluators:</h4>
+                            <div class="row">
+                                {{#each evaluatorSets}}
+                                <div class="col-sm-3">
+                                    {{this.setName}}:
                                 </div>
+                                <div class="col-sm-9">
+                                    <p>{{this.evaluators}}</p>
+                                </div>
+                                {{/each}}
                             </div>
                         </div>
                     </div>
-                    <div class="row justify-content-center margin-top-5percent">
-                        <div class="col-4">
-                            <form action="./exportData"
-                                  method="POST">
-                                <div class="form-group">
-                                    <label for="language">Select Language:</label>
-                                    <select class="form-control"
-                                            name="language"
-                                            required>
-                                        {{#each languageOptions}}
-                                        <option value={{this.language}}>{{this.displayName}}</option>
-                                        {{/each}}
-                                    </select>
-                                </div>
-                                <div class="form-group">
-                                    <button type="submit"
-                                            class="btn button-primary btn-block">Download</button>
-                                </div>
-                            </form>
-                        </div>
+                </div>
+                <div class="row justify-content-center margin-top-5percent">
+                    <div class="col-4">
+                        <form action="./exportData" method="POST">
+                            <div class="form-group">
+                                <label for="language">Select Language:</label>
+                                <select class="form-control" name="language" required>
+                                    {{#each languageOptions}}
+                                    <option value={{this}}>{{this}}</option>
+                                    {{/each}}
+                                </select>
+                            </div>
+                            <div class="form-group">
+                                <button type="submit" class="btn button-primary btn-block">Download</button>
+                            </div>
+                        </form>
                     </div>
                 </div>
             </div>
         </div>
-    </body>
+    </div>
+</body>
 
 </html>


### PR DESCRIPTION
Removing checks for specified supported languages so that any language set can be uploaded

Changes:
- remove Langauge enum type and replace it with type string
- remove Langauge enum checks and tests
- when uploading a new dataset targetLangauge and sourceLanguage should now be specified in the JSON file
