### PR TITLE
Extend access to external

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   },
   "spec": {
     "requires": [
-      "cloud-httpd24-ssl-services-devs-staff"
+      "cloud-httpd24-ssl-no-certs"
     ],
     "executable": [
       "./bake-scripts/*"


### PR DESCRIPTION
Allow access outside of the BBC so that DW staff can complete evaluation tasks