### PR TITLE
Revert "Extend access to external"

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   },
   "spec": {
     "requires": [
-      "cloud-httpd24-ssl-no-certs"
+      "cloud-httpd24-ssl-services-devs-staff"
     ],
     "executable": [
       "./bake-scripts/*"


### PR DESCRIPTION
Reverts bbc/gourmet-sentence-pairs-evaluation#65

There is a problem with using log in in production revert