### PR TITLE
Enable password protection on pages where evaluation data is viewed or edited

### DIFF
--- a/docs/admin.md
+++ b/docs/admin.md
@@ -68,7 +68,7 @@ There are also optional parameters that can be provided to enable basic user aut
 
 ## Security
 
-The software comes with optional [basic access authentication](https://en.wikipedia.org/wiki/Basic_access_authentication). This is enabled via the `ENABLE_AUTH` environment variable. If it is set to true when the user tries to access the site they will be presented with a login pop up. Once the user has logged in they will be able to freely access all of the site.
+The software comes with optional [basic access authentication](https://en.wikipedia.org/wiki/Basic_access_authentication). This is enabled via the `ENABLE_AUTH` environment variable. If it is set to true when the user tries to access pages on the site that allow them to view or submit evaluation data they will be presented with a login pop up. They will only need to login once. Once the user has logged in they will be able to freely access all of the site.
 
 ![](./images/login.png)
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -112,3 +112,13 @@ The Docker image is hosted on [Dockerhub](https://hub.docker.com/r/newslabsgourm
 ```
 docker push newslabsgourmet/direct-assessment-sentence-pair-tool:CURRENT_VERSION_NUMBER
 ```
+
+## Log In and Secure Router
+
+The application allows users to view and submit evaluation data. The BBC use case requires users from multiple organisations to access this tool. All pages that should only be available to authorized users are protected using [basic access authentication](https://en.wikipedia.org/wiki/Basic_access_authentication) which requires a user to provide a username and password before accessing a page.
+
+### Implementation
+
+The `/auth` path of the application is password protected using the [`express-basic-auth`](https://www.npmjs.com/package/express-basic-auth) library. The [secure router](../src/utils/secureRouter.ts) implements the basic auth and is used to serve password protected sub paths e.g. `/auth/evaluation`, `\auth\feedback` etc. so that multiple pages can be password protected.
+
+Authentication of the app is turned on and off by setting the `ENABLE_AUTH` environment variable to 'true' or 'false'. The username and password are set using the environment variables `USERNAME` and `PASSWORD`.

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,7 +2,7 @@ import * as express from 'express';
 import { Application } from 'express';
 import * as multer from 'multer';
 import { Instance } from 'multer';
-import * as basicAuth from 'express-basic-auth';
+import secureRouter from './utils/secureRouter';
 
 import { buildIndexRoute } from './routes/index';
 import { buildBeginEvaluationRoute } from './routes/beginEvaluation';
@@ -20,30 +20,11 @@ import './config';
 
 const app: Application = express();
 
-// support parsing of application/json type post data
-app.use(express.json());
-// support parsing of application/x-www-form-urlencoded post data
-app.use(express.urlencoded({ extended: true }));
 // Serve static assets in the public folder
 app.use(express.static('public'));
-// Enable Log in
-if (process.env.ENABLE_AUTH === 'true') {
-  if (
-    process.env.PASSWORD === undefined ||
-    process.env.USERNAME === undefined
-  ) {
-    throw new Error(
-      'Log in cannot be enabled on the tool unless a password and username are specified in the config.'
-    );
-  } else {
-    app.use(
-      basicAuth({
-        users: { [process.env.USERNAME]: process.env.PASSWORD },
-        challenge: true, // To show login UI
-      })
-    );
-  }
-}
+
+// Enable password authentication on any path starting with /auth
+app.use('/auth', secureRouter);
 
 // Use handlebars to render templates
 app.set('view engine', 'hbs');
@@ -51,15 +32,16 @@ app.set('view engine', 'hbs');
 const upload: Instance = multer({ dest: 'uploads/' });
 
 buildIndexRoute(app);
-buildStartRoute(app);
-buildBeginEvaluationRoute(app);
-buildEvaluationRoutes(app);
-buildFeedbackRoutes(app);
-buildDatasetRoutes(app, upload);
 buildEndRoute(app);
 buildSuccessRoute(app);
 buildErrorRoute(app);
 buildStatusRoute(app);
-buildExportDataRoute(app);
+
+buildStartRoute(secureRouter);
+buildBeginEvaluationRoute(secureRouter);
+buildEvaluationRoutes(secureRouter);
+buildFeedbackRoutes(secureRouter);
+buildDatasetRoutes(secureRouter, upload);
+buildExportDataRoute(secureRouter);
 
 export default app;

--- a/src/routes/__tests__/exportData.test.ts
+++ b/src/routes/__tests__/exportData.test.ts
@@ -31,7 +31,7 @@ describe('GET /exportData', () => {
         ),
       ]);
     });
-    const response = await mockApp.get('/exportData');
+    const response = await mockApp.get('/auth/exportData');
     expect(response.status).toBe(200);
   });
 });
@@ -72,7 +72,9 @@ describe('POST /exportData', () => {
       ]);
     });
 
-    const response = await mockApp.post('/exportData').send({ language: 'sw' });
+    const response = await mockApp
+      .post('/auth/exportData')
+      .send({ language: 'sw' });
     expect(response.status).toBe(200);
     expect(response.header['content-disposition']).toEqual(
       'attachment; filename="sw.zip"'
@@ -98,7 +100,7 @@ describe('POST /exportData', () => {
     });
 
     const response = await mockApp
-      .post('/exportData')
+      .post('/auth/exportData')
       .send({ language: 'SWAHILI' });
     expect(response.status).toBe(500);
     expect(response.header['location']).toEqual(
@@ -128,7 +130,7 @@ describe('POST /exportData', () => {
     });
 
     const response = await mockApp
-      .post('/exportData')
+      .post('/auth/exportData')
       .send({ language: 'SWAHILI' });
     expect(response.status).toBe(500);
     expect(response.header['location']).toEqual(

--- a/src/routes/beginEvaluation.ts
+++ b/src/routes/beginEvaluation.ts
@@ -1,11 +1,11 @@
-import { Response, Application } from 'express';
+import { Response, Router } from 'express';
 import { getSentenceSet, putSentenceSet } from '../DynamoDB/dynamoDBApi';
 import { StartRequest } from '../models/requests';
 import { SentenceSet } from '../models/models';
 import { logger } from '../utils/logger';
 
-const buildBeginEvaluationRoute = (app: Application) => {
-  app.post('/beginEvaluation', (req: StartRequest, res: Response) => {
+const buildBeginEvaluationRoute = (router: Router) => {
+  router.post('/beginEvaluation', (req: StartRequest, res: Response) => {
     const setId = req.body.setId;
     const evaluatorId = req.body.evaluatorId;
     getSentenceSet(setId)
@@ -16,7 +16,7 @@ const buildBeginEvaluationRoute = (app: Application) => {
               sentenceSet.sentenceIds || new Set()
             );
             res.redirect(
-              `/evaluation?setId=${setId}&evaluatorId=${evaluatorId}&setSize=${sentenceIdsList.length}&currentSentenceNum=0`
+              `/auth/evaluation?setId=${setId}&evaluatorId=${evaluatorId}&setSize=${sentenceIdsList.length}&currentSentenceNum=0`
             );
           })
           .catch(error => {

--- a/src/routes/dataset.ts
+++ b/src/routes/dataset.ts
@@ -1,4 +1,4 @@
-import { Request, Response, Application } from 'express';
+import { Request, Response, Router } from 'express';
 import { DatasetBody, DatasetFile, DatasetRequest } from '../models/requests';
 import { submitDataset } from '../processDataset';
 import { readFileSync, unlink } from 'fs';
@@ -14,8 +14,8 @@ const JSONvalidate = (sentences: string): DatasetFile => {
   }
 };
 
-const buildDatasetRoutes = (app: Application, upload: Instance) => {
-  app.post(
+const buildDatasetRoutes = (router: Router, upload: Instance) => {
+  router.post(
     '/dataset',
     upload.single('sentences'),
     (req: DatasetRequest, res: Response) => {
@@ -49,7 +49,7 @@ const buildDatasetRoutes = (app: Application, upload: Instance) => {
     }
   );
 
-  app.get('/dataset', (req: Request, res: Response) => {
+  router.get('/dataset', (req: Request, res: Response) => {
     res.render('dataset');
   });
 };

--- a/src/routes/evaluation.ts
+++ b/src/routes/evaluation.ts
@@ -1,4 +1,4 @@
-import { Request, Response, Application } from 'express';
+import { Request, Response, Router } from 'express';
 import {
   getSentenceSet,
   getSentencePair,
@@ -11,8 +11,8 @@ import {
 import { logger } from '../utils/logger';
 import { SentencePairScore } from '../models/models';
 
-const buildEvaluationRoutes = (app: Application) => {
-  app.post(
+const buildEvaluationRoutes = (router: Router) => {
+  router.post(
     '/evaluation',
     (req: SentencePairEvaluationRequest, res: Response) => {
       const body: SentencePairEvaluationRequestBody = req.body;
@@ -44,7 +44,7 @@ const buildEvaluationRoutes = (app: Application) => {
       putSentencePairScore(sentencePairScore)
         .then(() =>
           res.redirect(
-            `/evaluation?setId=${setId}&evaluatorId=${evaluatorId}&setSize=${setSize}&sentenceNum=${sentenceNum}`
+            `/auth/evaluation?setId=${setId}&evaluatorId=${evaluatorId}&setSize=${setSize}&sentenceNum=${sentenceNum}`
           )
         )
         .catch(error => {
@@ -56,7 +56,7 @@ const buildEvaluationRoutes = (app: Application) => {
     }
   );
 
-  app.get('/evaluation', (req: Request, res: Response) => {
+  router.get('/evaluation', (req: Request, res: Response) => {
     const setId: string = req.query.setId;
     const evaluatorId: string = req.query.evaluatorId;
     const setSize: number = Number(req.query.setSize || 0);
@@ -91,7 +91,7 @@ const buildEvaluationRoutes = (app: Application) => {
             });
         } else {
           res.redirect(
-            `/feedback?setId=${setId}&evaluatorId=${evaluatorId}&targetLanguage=${sentenceSet.targetLanguage}`
+            `/auth/feedback?setId=${setId}&evaluatorId=${evaluatorId}&targetLanguage=${sentenceSet.targetLanguage}`
           );
         }
       })

--- a/src/routes/exportData.ts
+++ b/src/routes/exportData.ts
@@ -1,4 +1,4 @@
-import { Request, Response, Application } from 'express';
+import { Request, Response, Router } from 'express';
 import {
   getSentencePairScores,
   getSentenceSetFeedback,
@@ -17,13 +17,13 @@ import { groupBy, flatten, sortBy } from 'underscore';
 import { createWriteStream } from 'fs';
 import * as archiver from 'archiver';
 
-const buildExportDataRoute = (app: Application) => {
-  getExportData(app);
-  postExportData(app);
+const buildExportDataRoute = (router: Router) => {
+  getExportData(router);
+  postExportData(router);
 };
 
-const getExportData = (app: Application) => {
-  app.get('/exportData', (req: Request, res: Response) => {
+const getExportData = (router: Router) => {
+  router.get('/exportData', (req: Request, res: Response) => {
     getSentenceSets()
       .then(sentenceSets => {
         const evaluatorSets = sentenceSets
@@ -61,8 +61,8 @@ const convertSentenceSetToEvaluatorSet = (
   };
 };
 
-const postExportData = (app: Application) => {
-  app.post('/exportData', (req: ExportRequest, res: Response) => {
+const postExportData = (router: Router) => {
+  router.post('/exportData', (req: ExportRequest, res: Response) => {
     sendData(req.body.language, res);
   });
 };

--- a/src/routes/feedback.ts
+++ b/src/routes/feedback.ts
@@ -1,10 +1,10 @@
-import { Request, Response, Application } from 'express';
+import { Request, Response, Router } from 'express';
 import { putSentenceSetFeedback } from '../DynamoDB/dynamoDBApi';
 import { FeedbackRequest } from '../models/requests';
 import { logger } from '../utils/logger';
 
-const buildFeedbackRoutes = (app: Application) => {
-  app.post('/feedback', (req: FeedbackRequest, res: Response) => {
+const buildFeedbackRoutes = (router: Router) => {
+  router.post('/feedback', (req: FeedbackRequest, res: Response) => {
     const feedback: string = req.body.feedback;
     const setId: string = req.body.setId;
     const evaluatorId: string = req.body.evaluatorId;
@@ -19,7 +19,7 @@ const buildFeedbackRoutes = (app: Application) => {
       });
   });
 
-  app.get('/feedback', (req: Request, res: Response) => {
+  router.get('/feedback', (req: Request, res: Response) => {
     const setId = req.query.setId;
     const evaluatorId = req.query.evaluatorId;
     const targetLanguage = req.query.targetLanguage;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -3,8 +3,8 @@ import { Request, Response, Application } from 'express';
 const buildIndexRoute = (app: Application) => {
   app.get('/', (req: Request, res: Response) => {
     res.render('index', {
-      datasetSubmissionUrl: '/dataset',
-      exportDataUrl: '/exportData',
+      datasetSubmissionUrl: '/auth/dataset',
+      exportDataUrl: '/auth/exportData',
     });
   });
 };

--- a/src/routes/start.ts
+++ b/src/routes/start.ts
@@ -1,8 +1,8 @@
-import { Request, Response, Application } from 'express';
+import { Request, Response, Router } from 'express';
 import { getSentenceSets } from '../DynamoDB/dynamoDBApi';
 
-const buildStartRoute = (app: Application) => {
-  app.get('/start', (req: Request, res: Response) => {
+const buildStartRoute = (router: Router) => {
+  router.get('/start', (req: Request, res: Response) => {
     const setId = req.query.setId;
     getSentenceSets().then(sentenceSets => {
       const sentenceSetOptions = sentenceSets

--- a/src/routes/success.ts
+++ b/src/routes/success.ts
@@ -5,7 +5,7 @@ const buildSuccessRoute = (app: Application) => {
     res.render('infoButtonGeneric', {
       title: 'Successfully Submitted Dataset',
       subtitle: '',
-      url: '/dataset',
+      url: '/auth/dataset',
       buttonText: 'Submit another data set',
     });
   });

--- a/src/utils/secureRouter.ts
+++ b/src/utils/secureRouter.ts
@@ -1,0 +1,33 @@
+import * as express from 'express';
+import { Router } from 'express';
+import * as basicAuth from 'express-basic-auth';
+
+const secureRouter: Router = Router();
+
+// support parsing of application/x-www-form-urlencoded post data
+secureRouter.use(express.urlencoded({ extended: true }));
+// support parsing of application/json type post data
+secureRouter.use(express.json());
+// Serve static assets in the public folder
+secureRouter.use(express.static('public'));
+
+// Enable Log in
+if (process.env.ENABLE_AUTH === 'true') {
+  if (
+    process.env.PASSWORD === undefined ||
+    process.env.USERNAME === undefined
+  ) {
+    throw new Error(
+      'Log in cannot be enabled on the tool unless a password and username are specified in the config.'
+    );
+  } else {
+    secureRouter.use(
+      basicAuth({
+        users: { [process.env.USERNAME]: process.env.PASSWORD },
+        challenge: true, // To show login UI
+      })
+    );
+  }
+}
+
+export default secureRouter;

--- a/views/dataset.hbs
+++ b/views/dataset.hbs
@@ -1,34 +1,42 @@
 <!DOCTYPE html>
 <html>
 
-<head>
-    <link rel="shortcut icon" href="media/favicon.ico" type="image/x-icon" />
-    <!-- Adding bootstrap CSS styles -->
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
-        integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+    <head>
+        <link rel="shortcut icon"
+              href="media/favicon.ico"
+              type="image/x-icon" />
+        <!-- Adding bootstrap CSS styles -->
+        <link rel="stylesheet"
+              href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
+              integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T"
+              crossorigin="anonymous">
 
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+        <meta charset="utf-8">
+        <meta name="viewport"
+              content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-    <title>Sentence Pairs</title>
-    <link rel="stylesheet" type="text/css" href="main.css" />
-</head>
+        <title>Sentence Pairs</title>
+        <link rel="stylesheet"
+              type="text/css"
+              href="main.css" />
+    </head>
 
-<body class="bg-grey">
-    <div>
-        <img class="gourmet_logo" src="./media/horizontal_light.png" />
-    </div>
-    <div class="container">
-        <div class="row justify-content-center">
-            <div class="col-sm-10 text-primary-dark-grey">
-                <h1 class="text-center text-primary-mid-green">Text for Evaluation</h1>
-                <p class="margin-top-5percent">This page is for submission of data sets to be evaluated. The user
-                    MUST give a name for the sentence set as well as the source language and target language. This
-                    name will be given to evaluators to identify the data set they should analyse. The file provided
-                    MUST be a json file containing JSON of the following form:
-                </p>
-                <p>
-                <pre><code>
+    <body class="bg-grey">
+        <div>
+            <img class="gourmet_logo"
+                 src="./media/horizontal_light.png" />
+        </div>
+        <div class="container">
+            <div class="row justify-content-center">
+                <div class="col-sm-10 text-primary-dark-grey">
+                    <h1 class="text-center text-primary-mid-green">Text for Evaluation</h1>
+                    <p class="margin-top-5percent">This page is for submission of data sets to be evaluated. The user
+                        MUST give a name for the sentence set as well as the source language and target language. This
+                        name will be given to evaluators to identify the data set they should analyse. The file provided
+                        MUST be a json file containing JSON of the following form:
+                    </p>
+                    <p>
+                    <pre><code>
                     {
                     "possibleEvaluatorIds": list[string],
                     "sourceLanguage": string,
@@ -37,12 +45,12 @@
                     }
                     </code>
                     </pre>
-                </p>
-                <p>
-                    Where Sentences is of type:
-                </p>
-                <p>
-                <pre><code>
+                    </p>
+                    <p>
+                        Where Sentences is of type:
+                    </p>
+                    <p>
+                    <pre><code>
                     {
                     "original": string,
                     "humanTranslation": string,
@@ -50,28 +58,37 @@
                     "sentencePairType": string
                     }
                     </code></pre>
-                </p>
-                <form action="/dataset" method="POST" enctype="multipart/form-data">
-                    <div class="form-row">
-                        <div class="form-group col-md-4">
+                    </p>
+                    <form action="/auth/dataset"
+                          method="POST"
+                          enctype="multipart/form-data">
+                        <div class="form-row">
+                            <div class="form-group col-md-4">
 
-                            <label for="setName">Name of Sentence Set</label>
-                            <input class="form-control" name="setName" id="setName" required></input>
+                                <label for="setName">Name of Sentence Set</label>
+                                <input class="form-control"
+                                       name="setName"
+                                       id="setName"
+                                       required></input>
+                            </div>
                         </div>
-                    </div>
-                    <div class="form-group">
-                        <label for="sentences">Choose file</label>
-                        <input type="file" class="form-control-file" name="sentences" required>
-                    </div>
-                    <div class="form-row justify-content-center">
-                        <div class="form-group col-md-2">
-                            <button type="submit" class="btn button-primary btn-block">Submit</button>
+                        <div class="form-group">
+                            <label for="sentences">Choose file</label>
+                            <input type="file"
+                                   class="form-control-file"
+                                   name="sentences"
+                                   required>
                         </div>
-                    </div>
-                </form>
+                        <div class="form-row justify-content-center">
+                            <div class="form-group col-md-2">
+                                <button type="submit"
+                                        class="btn button-primary btn-block">Submit</button>
+                            </div>
+                        </div>
+                    </form>
+                </div>
             </div>
         </div>
-    </div>
-</body>
+    </body>
 
 </html>

--- a/views/evaluation.hbs
+++ b/views/evaluation.hbs
@@ -51,7 +51,7 @@
                         </div>
                         <div class="row margin-top-5percent">
                             <div class="col">
-                                <form action="/evaluation"
+                                <form action="/auth/evaluation"
                                       enctype="application/x-www-form-urlencoded"
                                       method="POST">
 

--- a/views/exportData.hbs
+++ b/views/exportData.hbs
@@ -1,66 +1,78 @@
 <!DOCTYPE html>
 <html>
 
-<head>
-    <link rel="shortcut icon" href="media/favicon.ico" type="image/x-icon" />
-    <!-- Adding bootstrap CSS styles -->
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
-        integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+    <head>
+        <link rel="shortcut icon"
+              href="media/favicon.ico"
+              type="image/x-icon" />
+        <!-- Adding bootstrap CSS styles -->
+        <link rel="stylesheet"
+              href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
+              integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T"
+              crossorigin="anonymous">
 
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+        <meta charset="utf-8">
+        <meta name="viewport"
+              content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-    <title>Sentence Pairs</title>
-    <link rel="stylesheet" type="text/css" href="main.css" />
-</head>
+        <title>Sentence Pairs</title>
+        <link rel="stylesheet"
+              type="text/css"
+              href="main.css" />
+    </head>
 
-<body class="bg-grey">
-    <div>
-        <img class="gourmet_logo" src="./media/horizontal_light.png" />
-    </div>
-    <div class="container">
-        <div class="row align-items-center">
-            <div class="col">
-                <div class="row">
-                    <div class="col">
-                        <h1 class="text-center text-primary-mid-green">Export Data and Feedback</h1>
-                        <h2 class="text-center text-primary-dark-grey">Downloads may take a few minutes depending on
-                            the size of the data set.</h2>
-                        <div class="row margin-top-5percent">
-                            <h4>Current Evaluators:</h4>
-                            <div class="row">
-                                {{#each evaluatorSets}}
-                                <div class="col-sm-3">
-                                    {{this.setName}}:
+    <body class="bg-grey">
+        <div>
+            <img class="gourmet_logo"
+                 src="./media/horizontal_light.png" />
+        </div>
+        <div class="container">
+            <div class="row align-items-center">
+                <div class="col">
+                    <div class="row">
+                        <div class="col">
+                            <h1 class="text-center text-primary-mid-green">Export Data and Feedback</h1>
+                            <h2 class="text-center text-primary-dark-grey">Downloads may take a few minutes depending on
+                                the size of the data set.</h2>
+                            <div class="row margin-top-5percent">
+                                <h4>Current Evaluators:</h4>
+                                <div class="row">
+                                    {{#each evaluatorSets}}
+                                    <div class="col-sm-3">
+                                        {{this.setName}}:
+                                    </div>
+                                    <div class="col-sm-9">
+                                        <p>{{this.evaluators}}</p>
+                                    </div>
+                                    {{/each}}
                                 </div>
-                                <div class="col-sm-9">
-                                    <p>{{this.evaluators}}</p>
-                                </div>
-                                {{/each}}
                             </div>
                         </div>
                     </div>
-                </div>
-                <div class="row justify-content-center margin-top-5percent">
-                    <div class="col-4">
-                        <form action="./exportData" method="POST">
-                            <div class="form-group">
-                                <label for="language">Select Language:</label>
-                                <select class="form-control" name="language" required>
-                                    {{#each languageOptions}}
-                                    <option value={{this}}>{{this}}</option>
-                                    {{/each}}
-                                </select>
-                            </div>
-                            <div class="form-group">
-                                <button type="submit" class="btn button-primary btn-block">Download</button>
-                            </div>
-                        </form>
+                    <div class="row justify-content-center margin-top-5percent">
+                        <div class="col-4">
+                            <form action="./exportData"
+                                  method="POST">
+                                <div class="form-group">
+                                    <label for="language">Select Language:</label>
+                                    <select class="form-control"
+                                            name="language"
+                                            required>
+                                        {{#each languageOptions}}
+                                        <option value={{this}}>{{this}}</option>
+                                        {{/each}}
+                                    </select>
+                                </div>
+                                <div class="form-group">
+                                    <button type="submit"
+                                            class="btn button-primary btn-block">Download</button>
+                                </div>
+                            </form>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
-    </div>
-</body>
+    </body>
 
 </html>

--- a/views/feedback.hbs
+++ b/views/feedback.hbs
@@ -45,7 +45,7 @@
                                 learning and artificial neural networks.</p>
                             <p>Once you’ve written your comments you’ll be able to complete the evaluation by clicking
                                 on 'finish’ below.</p>
-                            <form action="/feedback"
+                            <form action="/auth/feedback"
                                   method="POST">
                                 <div class="row justify-content-center form-group">
                                     <div class="col">

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -46,7 +46,7 @@
                     </div>
 
                     <form class="margin-top-5percent"
-                          action="/start"
+                          action="/auth/start"
                           method="GET">
                         <div class="row justify-content-center form-group">
                             <div class="col-md-2">

--- a/views/start.hbs
+++ b/views/start.hbs
@@ -46,18 +46,20 @@
                         </div>
                     </div>
                     <form class="text-primary-dark-grey"
-                          action="/beginEvaluation"
+                          action="/auth/beginEvaluation"
                           method="POST">
                         <div class="row justify-content-center form-group">
                             <div class="col-md-6">
                                 <label for="setId">Pick the set you have been asked to evaluate:</label>
-                                <select class="form-control"       
+                                <select class="form-control"
                                         name="setId"
                                         onchange="javascript:location.search = '?setId=' + this.value;"
                                         required>
-                                    <option disabled selected>Pick a set</option>
+                                    <option disabled
+                                            selected>Pick a set</option>
                                     {{#each sentenceSetOptions}}
-                                    <option {{#if this.isSelected}}selected{{/if}} value="{{this.sentenceSet.setId}}">{{this.sentenceSet.name}}</option>
+                                    <option {{#if this.isSelected}}selected{{/if}}
+                                            value="{{this.sentenceSet.setId}}">{{this.sentenceSet.name}}</option>
                                     {{/each}}
                                 </select>
                             </div>
@@ -65,11 +67,12 @@
                         <div class="row justify-content-center form-group">
                             <div class="col-md-6">
                                 <label for="evaluatorId">Select your evaluator ID:</label>
-                                <select {{#unless possibleEvaluatorIds.length}}disabled{{/unless}} 
+                                <select {{#unless possibleEvaluatorIds.length}}disabled{{/unless}}
                                         class="form-control"
                                         name="evaluatorId"
                                         required>
-                                    <option disabled selected>Pick an evaluator ID</option>
+                                    <option disabled
+                                            selected>Pick an evaluator ID</option>
                                     {{#each possibleEvaluatorIds}}
                                     <option value={{this}}>{{this}}</option>
                                     {{/each}}


### PR DESCRIPTION
What's changed:
- Use express router to require log in on pages where evaluation data can be viewed or modified. This approach allows the use of basic auth which is quicker and simpler to implement than a full log in system whilst still having roots that should not be password protected e.g. the `/status` root for healthchecks
- This works by requiring passwords on all paths that are a subpath of `/auth`