### PR TITLE
feat: UI RTL text support for pastho and urdu

### DIFF
--- a/public/main.css
+++ b/public/main.css
@@ -114,3 +114,8 @@ html {
   height: 7vh; /* Set the fixed height of the footer here */
   line-height: 7vh; /* Vertically center the text there */
 }
+
+.text__rtl {
+  direction: rtl;
+  text-align: right;
+}

--- a/src/routes/evaluation.ts
+++ b/src/routes/evaluation.ts
@@ -61,6 +61,8 @@ const buildEvaluationRoutes = (router: Router) => {
     const evaluatorId: string = req.query.evaluatorId;
     const setSize: number = Number(req.query.setSize || 0);
     const sentenceNum: number = Number(req.query.sentenceNum || 0);
+    const RTL_LANGS = ['ur', 'ps'];
+
     getSentenceSet(setId)
       .then(sentenceSet => {
         const idList: string[] = Array.from(
@@ -75,6 +77,9 @@ const buildEvaluationRoutes = (router: Router) => {
                 sentence2: sentencePair.machineTranslation,
                 original: sentencePair.original,
                 targetLanguage: sentencePair.targetLanguage,
+                isRtl: RTL_LANGS.includes(
+                  sentencePair.targetLanguage.toLowerCase()
+                ),
                 setId,
                 sentencePairType: sentencePair.sentencePairType,
                 sentencePairId,

--- a/views/evaluation.hbs
+++ b/views/evaluation.hbs
@@ -41,12 +41,12 @@
                     <div class="evaluation__form">
                         <div class="row">
                             <div class="col-sm-12">
-                                <p class="text-grey">{{sentence1}}</p>
+                                <p class="text-grey {{#if isRtl}} text__rtl {{/if}}">{{sentence1}}</p>
                             </div>
                         </div>
                         <div class="row">
                             <div class="col-sm-12">
-                                <p class="text-black">{{sentence2}}</p>
+                                <p class="text-black {{#if isRtl}} text__rtl {{/if}}">{{sentence2}}</p>
                             </div>
                         </div>
                         <div class="row margin-top-5percent">


### PR DESCRIPTION
Support for RTL langs (Pashto and Urdu) in Sentence Pairs UI

To locally test the UI select **Test TRL Set** (it's a Pashto dataset)

UI changes: 
<img width="1001" alt="Screenshot 2021-12-09 at 16 43 12" src="https://user-images.githubusercontent.com/39386043/145441125-a0c41d01-4e39-4ebc-bc76-48e25ec315a3.png">

